### PR TITLE
Update the cookie banner rule for the instagram.com.

### DIFF
--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -411,7 +411,7 @@
       "click": {
         "optIn": "div[role=dialog] > div > button",
         "optOut": "div[role=dialog] > div > button + button",
-        "presence": "div[role=presentation]"
+        "presence": "#scrollview + div"
       },
       "domain": "instagram.com",
       "cookies": {},


### PR DESCRIPTION
The current rule for Instagram isn't working, this push fixes that.