### PR TITLE
QA cookie banner rules update

### DIFF
--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -2182,6 +2182,5269 @@
         ]
       },
       "id": "d46017a3-bd38-41d2-9e2c-3c0a0b729e99"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "presence": "div#buttons"
+      },
+      "domain": "aktualne.cz",
+      "cookies": {
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPgejgAPgejgAAHABBENCjCgAAAAAAAAAATIAAAAAACBoAMAAQSCEQAYAAgkEKgAwABBIIZABgACCQQA.YAAAAAAAAAAA"
+          }
+        ]
+      },
+      "id": "9399f790-0b3e-4ff1-8dd9-b06994043270"
+    },
+    {
+      "click": {
+        "optIn": "button.css-1j8kkja",
+        "presence": "div.qc-cmp2-summary-buttons"
+      },
+      "domain": "sport24.gr",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "cto_bundle",
+            "value": "cETUWl96SkZFS1NJQUlCR3lQZlZ1WUt3Z3BaMW9qVEU1U25BaFRXdiUyQk1FeDhIWUJkVmh1b1VqY2dTbTB4bmRsaHliT3FZcFhXNFF6bU5HeSUyQkFiSVBBZ1NtVWR0b0w3T3pVR3dUTUhKeWJtSElWJTJCVDlRREl4dSUyRmRJdDBiM2M0VUs3S3R4UXI3Sjd5NENTUHFXcll1MEFGejJLdyUzRCUzRA"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPgfy_fPgfy_fAKAnAELCkCgAAAAAH_AAAyIAAASIAJMNW4gC7MscGbQMIoEQIwrCQqgUAEFAMLRAYAODgp2VgE-sIEACAUARgRAhwBRgQCAAASAJCIAJAiwQAAAiAQAAgARCIQAMDAILACwMAgABANAxRCgAECQgyICIpTAgKgSCA1sqEEoLpDTCAOssAKCRGxUACIJARWAAICwcAwRICViwQJMUb5ACMEKAUSoVqIAAAAA.YAAAAAAAAAAA"
+          }
+        ]
+      },
+      "id": "02a059b8-09a4-488c-afa0-e208c4b8b84d"
+    },
+    {
+      "click": {
+        "optIn": "button#privacy-cor-wall-accept",
+        "presence": "div.privacy-cor-wall__wrapper_cmp"
+      },
+      "domain": "corriere.it",
+      "cookies": {},
+      "id": "caf3084b-dfc5-40ca-b66e-a477913efc67"
+    },
+    {
+      "click": {
+        "optIn": "button.cookie-banner__button",
+        "presence": "div#cookie-banner"
+      },
+      "domain": "tv2.no",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "tv2samtykke",
+            "value": "1"
+          }
+        ]
+      },
+      "id": "b2a31215-49cc-4edb-801d-09d6ec435848"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "presence": "div#buttons"
+      },
+      "domain": "elmundo.es",
+      "cookies": {},
+      "id": "bb475b86-e9f5-410a-a817-7537c3c197c0"
+    },
+    {
+      "click": {
+        "optIn": "button#usage_notice_button",
+        "presence": "div.button"
+      },
+      "domain": "censor.net",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "_accept_usage",
+            "value": "1"
+          }
+        ]
+      },
+      "id": "4e5a6503-adb4-4e4d-8113-f29a93bf11a7"
+    },
+    {
+      "click": {
+        "optIn": "button#onetrust-accept-btn-handler",
+        "presence": "div#onetrust-button-group"
+      },
+      "domain": "olx.bg",
+      "cookies": {
+        "optIn": [],
+        "optOut": [
+          {
+            "name": "eupubconsent-v2",
+            "value": "CPgf0V_Pgf0V_AcABBENCkCgAAAAAH_AAAYgJDtf_X__b2_r-_5_f_t0eY1P9_7__-0zjhfdl-8N3f_X_L8X52M7vF36tq4KuR4ku3LBIUdlHOHcTUmw6okVryPsbk2cr7NKJ7PEmnMbOydYGH9_n1_z-ZKY7___f_7z_v-v___3____7-3f3__5___-__e_V__9zfn9_____9vP___9v-_9__________3_7994JCAEmGrcQBdiWOBNtGEUCIEYVhIdQKACigGFogMIHVwU7K4CfWECABAKAIwIgQ4AowYBAAABAEhEQEgR4IBAARAIAAQAKhEIACNgEFABYGAQACgGhYoxQBCBIQZEBEUpgQESJBQT2VCCUH-hphCHWWAFBo_4qEBEoAQrAiEhYOQ4IkBLxZIFmKN8gBGCFAKJUK1AAAAA.YAAAD_gAAAAA"
+          }
+        ]
+      },
+      "id": "4a8c3a93-091e-4511-9961-878e2a1102cd"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "presence": "div#buttons"
+      },
+      "domain": "dnevnik.hr",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "cto_bundle",
+            "value": "Ae-x_l9xYVJ0UGdFN3UyJTJCNXlncFlLTXM5V2pXd2x5YUNrNGdwTkRYdjFtcTI0cUl0QlEyWTElMkZoTDVGbVJhR09rRE5sdE4xalc5UXpMcXNaMFE0S01XSFNIWjJSdThsT1hPc3IlMkIwTExscFolMkY3dHJsRWNvMHI0T2JZajU1b2NyTTlPQWdGeE5ndHRUTm12bkE5SlRQNkRwR2twUSUzRCUzRA"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPgejgAPgejgAAHABBENCjCgAAAAAAAAAAAAAAAAAAAA.YAAAAAAAAAAA"
+          }
+        ]
+      },
+      "id": "5be3ccda-f8fe-453b-8a53-0dc8143f7580"
+    },
+    {
+      "click": {
+        "optIn": "button#L2AGLb",
+        "optOut": "button#W0wltc",
+        "presence": "div.spoKVd"
+      },
+      "domain": "google.cz",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "CONSENT",
+            "value": "PENDING"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "SOCS",
+            "value": "CAESHAgBEhJnd3NfMjAyMjEwMDQtMF9SQzMaAnJvIAEaBgiA2P2ZBg"
+          }
+        ]
+      },
+      "id": "14df6f20-3dcd-4441-822b-d44b57d74136"
+    },
+    {
+      "click": {
+        "optIn": "button#onetrust-accept-btn-handler",
+        "presence": "div#onetrust-button-group"
+      },
+      "domain": "olx.pt",
+      "cookies": {},
+      "id": "e8d7ff4a-0c74-4976-904a-8330e2e76e80"
+    },
+    {
+      "click": {
+        "optIn": "button#onetrust-accept-btn-handler",
+        "presence": "div.banner-actions-container"
+      },
+      "domain": "rte.ie",
+      "cookies": {},
+      "id": "93cf2378-0054-416b-9832-5a9073190b26"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "presence": "div#buttons"
+      },
+      "domain": "b92.net",
+      "cookies": {
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPgejgAPgejgAAHABBENCjCgAAAAAF_AACKQAAAMkgNgALAAqABkADgAHgAQAAkABkADQAIoATIAngCgAFUAMwAhABHAClAFyAMoAc4A_QCEAGAAP-AvMBiwDJAAAAAA.YAAAC_gAAAAA"
+          }
+        ]
+      },
+      "id": "03271d25-de32-4f36-8798-e54874d10277"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "optOut": "button#didomi-notice-disagree-button",
+        "presence": "div#buttons"
+      },
+      "domain": "pravda.sk",
+      "cookies": {
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPgejgAPgejgAAHABBENCjCgAAAAAH_AAAAAAAASCAJMNW4gC7EscCbaMIoEQIwrCQ6gUAFFAMLRAYQOrgp2VwE-sIEACAUARgRAhxBRgwCAAACAJCIgJAjwQCIAiAQAAgAVCIQAEbAIKACwMAgAFANCxRigCECQgyICIpTAgIkSCgnsqEEoO9DTCEOssAKDR_xUICJQAhWBEJCwchwRICXiyQLMUb5ACMEKAUSoVoAA.YAAAD_gAAAAA"
+          }
+        ]
+      },
+      "id": "28b289d7-68c2-44cc-8b57-9dff344cce18"
+    },
+    {
+      "click": {
+        "optIn": "button#accept-ufti",
+        "presence": "div.Modal__Content-sc-1sm9281-2"
+      },
+      "domain": "blocket.se",
+      "cookies": {
+        "optOut": [
+          {
+            "name": "ufti",
+            "value": "%7B%22facebook%22%3Afalse%2C%22google%22%3Afalse%2C%22version%22%3A2%7D"
+          }
+        ]
+      },
+      "id": "12b031c4-abfd-4156-a83c-5e8418f4a866"
+    },
+    {
+      "click": {
+        "optIn": "button#onetrust-accept-btn-handler",
+        "presence": "div#onetrust-button-group-parent"
+      },
+      "domain": "heute.at",
+      "cookies": {
+        "optOut": [
+          {
+            "name": "eupubconsent-v2",
+            "value": "CPgf4qBPgf4qBAcABBENCkCgAAAAAAAAAChQAAAAAAAA.YAAAAAAAAAAA"
+          }
+        ]
+      },
+      "id": "d5ed805f-52a3-43e3-a648-d0a7ff64bbf3"
+    },
+    {
+      "click": {
+        "optIn": "button#onetrust-accept-btn-handler",
+        "presence": "div#onetrust-button-group"
+      },
+      "domain": "sportal.bg",
+      "cookies": {},
+      "id": "0171966d-896b-43eb-80a0-e51a5e1a6e24"
+    },
+    {
+      "click": {
+        "optIn": "button#L2AGLb",
+        "optOut": "button#W0wltc",
+        "presence": "div.spoKVd"
+      },
+      "domain": "google.hr",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "CONSENT",
+            "value": "PENDING"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "SOCS",
+            "value": "CAESHAgBEhJnd3NfMjAyMjEwMDMtMF9SQzEaAnJvIAEaBgiA2P2ZBg"
+          }
+        ]
+      },
+      "id": "28c5edf5-a434-42f9-864a-675b87e0a547"
+    },
+    {
+      "click": {
+        "optIn": "button#L2AGLb",
+        "optOut": "button#W0wltc",
+        "presence": "div.spoKVd"
+      },
+      "domain": "google.com.ua",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "CONSENT",
+            "value": "PENDING"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "SOCS",
+            "value": "CAESHAgBEhJnd3NfMjAyMjEwMDMtMF9SQzEaAnJvIAEaBgiA2P2ZBg"
+          }
+        ]
+      },
+      "id": "736570ce-b6be-4d11-ba54-af7074422174"
+    },
+    {
+      "click": {
+        "optIn": "button.fc-primary-button",
+        "presence": "div.fc-footer-buttons"
+      },
+      "domain": "fakti.bg",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "FCNEC",
+            "value": "%5B%5B%22AKsRol-3mNQRf7V9PA5kkJz3Z3uGCaqt3u5yHCFq7_B4oBKrw-cRqQsTCN43Sq5Bc_n1k7Pb2EyvVo8OHnX7LEL2KXJFfdg6-PpFYzA2wj_nYy6Zz_pb6Be13TaC58UmPS0LYPQrt9Vm4IjuFdDCNAOqp57ERHmA_g%3D%3D%22%5D%2Cnull%2C%5B%5D%5D"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "FCCDCF",
+            "value": "%5Bnull%2Cnull%2Cnull%2C%5B%22CPgejgAPgejgAEsABCBGCkCgAAAAAAAAAAIwAAAOhQD2F2K2kKEkfjSUWYAQBCujKEIhUAAAAECBIAAAAUgQAgFIIAgAAlACAAAAABAQAQCAgAQABAAAoACgAAAAAAAAAAAAAAQQAABAAIAAAAAAAAEAQAAIAAQAAAAAAABEhCAAQQAEAAAAAAAAAAAAAAAAAAABAAA%22%2C%221~%22%2C%2232D9A01E-9678-40B0-BD1B-AD0CDC174758%22%5D%2Cnull%2Cnull%2C%5B%5D%5D"
+          }
+        ]
+      },
+      "id": "abc3a8c3-6a15-48a6-83eb-4f7762df9270"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "presence": "div#buttons"
+      },
+      "domain": "njuskalo.hr",
+      "cookies": {
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPgejgAPgejgAAHABBENCjCgAAAAAAAAAAAAAAAAAAAA.YAAAAAAAAAAA"
+          }
+        ]
+      },
+      "id": "c59c10f1-a805-4a14-bc9b-ccabf8852306"
+    },
+    {
+      "click": {
+        "optIn": "button#L2AGLb",
+        "optOut": "button#W0wltc",
+        "presence": "div.spoKVd"
+      },
+      "domain": "google.no",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "CONSENT",
+            "value": "PENDING"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "SOCS",
+            "value": "CAESHAgBEhJnd3NfMjAyMjEwMDQtMF9SQzMaAnJvIAEaBgiA2P2ZBg"
+          }
+        ]
+      },
+      "id": "ddcbdc24-cfc0-45ac-a2ae-9b8471204204"
+    },
+    {
+      "click": {
+        "optIn": "button.fc-cta-consent",
+        "presence": "div.fc-footer-buttons-container"
+      },
+      "domain": "plovdiv24.bg",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "cto_bundle",
+            "value": "mGGsCV9yaTNCU1VNNFZNZHNZUmpjUlZFJTJGYnhQTjBLQlRHQWhPaERpakRnNFl0NHVwSHRUY1FEMkpuRHNabnkydHVrWmR3emhiSHlLRkNYcVpLeXVyb0p0RW96azJhUmI2eHpQVjElMkZqZVAlMkY4SVUlMkZVbGpZeDVtTUxNbHZVa3FiRzMxbFRFcmZEeW04dXZ3SHAzWlBYazFRYkVQdyUzRCUzRA"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "FCCDCF",
+            "value": "%5Bnull%2Cnull%2Cnull%2C%5B%22CPgejgAPgejgAEsABCBGCkCgAAAAAAAAAAIwAAAOhQD2F2K2kKEkfjSUWYAQBCujIEIhUAAAAECBIAAAAUgQAgFIIAgAAlACAAAAABAQAQCAgAQABAAAoACgAAAAAAAAAAAAAAQQAABAAIAAAAAAAAEAQAAIAAQAAAAAAABEhCAAQQAEAAAAAAAAAAAAAAAAAAABAAA.YAAAAAAAAAA%22%2C%221~%22%2C%22B14550D2-2C81-4087-B1D1-A35C539B751B%22%5D%2Cnull%2Cnull%2C%5B%5D%5D"
+          }
+        ]
+      },
+      "id": "1dbf0b53-df44-472c-a126-13740e9d2e39"
+    },
+    {
+      "click": {
+        "optIn": "button.eu-cookie-compliance-secondary-button",
+        "optOut": "button.eu-cookie-compliance-default-button",
+        "presence": "div#popup-buttons"
+      },
+      "domain": "gsis.gr",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "cookie-agreed",
+            "value": "1"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "cookie-agreed",
+            "value": "0"
+          }
+        ]
+      },
+      "id": "c3f6134c-061a-4828-ab89-b6f12015a1f3"
+    },
+    {
+      "click": {
+        "optIn": "button.t_cm_ec_continue_button",
+        "optOut": "button.t_cm_ec_reject_button",
+        "presence": "div.t_cm_ec_modal_footer"
+      },
+      "domain": "vodafone.com",
+      "cookies": {},
+      "id": "a4cb7b9f-0a47-4fc8-ac4c-5e9d0d598531"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "optOut": "button#didomi-notice-disagree-button",
+        "presence": "div#buttons"
+      },
+      "domain": "cas.sk",
+      "cookies": {},
+      "id": "c88d4f41-e00a-4a85-ac96-3d0fa033e75c"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "presence": "div#buttons"
+      },
+      "domain": "nova.bg",
+      "cookies": {
+        "optIn": [],
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPgejgAPgejgAAHABBENCjCgAAAAAAAAAAIwAAAAAABBoAMAAQSCEQAYAAgkEAAA.YAAAAAAAAAAA"
+          }
+        ]
+      },
+      "id": "6f634335-f79e-4190-a811-cd84dc760fbb"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "optOut": "button#didomi-notice-disagree-button",
+        "presence": "div#buttons"
+      },
+      "domain": "nova.cz",
+      "cookies": {},
+      "id": "cb4b1312-71dc-42d1-8242-560b48827d78"
+    },
+    {
+      "click": {
+        "optIn": "button#ocm-button.ocm-button--accept-all",
+        "optOut": "button.ocm-button--continue",
+        "presence": "div.ocm-footer"
+      },
+      "domain": "op.fi",
+      "cookies": {},
+      "id": "86b4e119-8e5c-471d-bf80-c65489277135"
+    },
+    {
+      "click": {
+        "optIn": "button#gdpr-consent-banner-accept-button",
+        "presence": "div.gdpr-consent-modal-footer"
+      },
+      "domain": "marktplaats.nl",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "cto_bundle",
+            "value": "WYw0QV9LdEpOOWZZYWlyV2Q5djNWa2RCZTlwbUlPTDBYN1pwZVIzJTJCc29nc2RLVXVNdElHQXNoRDdQYlAwZnhzJTJGSzBFQmNmQ21DQzJqUHIyN3RaUGxsZGVjSGgzbjMzc0RlTGtJY2I0MVRvUkhCNW9rU2xadzZlME9XQnhubW1jZSUyRm9pQ2hTOWl5VU9xdGIlMkZMS3phdFYlMkJhRE9BJTNEJTNE"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "MpTCString",
+            "value": "CPggWskPggWskE0ACCNLBiCgAAAAAAAAABpYAAAO8gFgA4AM-AwQBt4DcQG5gN8AdiA7YB3IDvAAAAAA.YAAAAAAAAYAA"
+          }
+        ]
+      },
+      "id": "2cb11bb1-1d52-45c7-a764-9d2e2be6c310"
+    },
+    {
+      "click": {
+        "optIn": "button#onetrust-accept-btn-handler",
+        "optOut": "button#onetrust-reject-all-handler",
+        "presence": "div#onetrust-banner-sdk"
+      },
+      "domain": "sport.ro",
+      "cookies": {},
+      "id": "085a75f5-2c12-432d-9eef-7856ef0134c7"
+    },
+    {
+      "click": {
+        "optIn": "button.sp_choice_type_11",
+        "presence": "div#notice"
+      },
+      "domain": "azet.sk",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "cto_bundle",
+            "value": "ldz0LF9yeFlGRWpLeWlCd1dEdmtTUEpNVlFMdVdWMUpydGRhNXJwZXhjeUlueEh5MkV2U2ZVVTVadDBmMThncjBuZUFHc2U0Q2YzYVRweEZSaGNYbThNNWFKZkFIaTlSWDlWams3SG1mRDNXajdDOXRVR3VwdWd0YTV4dVpidCUyQk5CdkRv"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPgejgAPgejgAAGABBENCkCgAAAAAAAAACJwAAAAAAAA.YAAAAAAAAAAA"
+          }
+        ]
+      },
+      "id": "10c7db87-9d97-4e6b-ad06-44ddd1a7411d"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "presence": "div#buttons"
+      },
+      "domain": "mundodeportivo.com",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "___nrbic",
+            "value": "%7B%22previousVisit%22%3A1665148689%2C%22currentVisitStarted%22%3A1665148689%2C%22sessionId%22%3A%223ef08a2c-ff90-42e7-a413-047031631eed%22%2C%22sessionVars%22%3A%5B%5D%2C%22visitedInThisSession%22%3Atrue%2C%22pagesViewed%22%3A1%2C%22landingPage%22%3A%22https%3A//www.mundodeportivo.com/%22%2C%22referrer%22%3A%22%22%7D"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPgejgAPgejgAAHABBENCjCgAAAAAAAAAAiQAAAAAAEhIAMAAQSCDQAYAAgkEIgAwABBIIVABgACCQQyADAAEEgh0AGAAIJBEIAMAAQSCJQAYAAgkEUgAwABBIIA.YAAAAAAAAAAA"
+          }
+        ]
+      },
+      "id": "570abe35-e406-4e47-9228-5fff95bd0687"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "presence": "div#buttons"
+      },
+      "domain": "dn.se",
+      "cookies": {
+        "optIn": [],
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPgejgAPgejgAAHABBENCjCgAAAAAAAAACQgAAAAAAAA.YAAAAAAAAAAA"
+          }
+        ]
+      },
+      "id": "49e7697f-934b-4bde-a73c-9ceff9498046"
+    },
+    {
+      "click": {
+        "optIn": "button#onetrust-accept-btn-handler",
+        "presence": "div#onetrust-button-group"
+      },
+      "domain": "bluewin.ch",
+      "cookies": {},
+      "id": "c9c536df-15d4-4370-8e7b-3fae233eac9d"
+    },
+    {
+      "click": {
+        "optIn": "button.sp_choice_type_11",
+        "presence": "div#notice"
+      },
+      "domain": "n-tv.de",
+      "cookies": {
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPgejgAPgejgAAGABBDECkCgAAAAAAAAACJwAAAAAAAA.YAAAAAAAAAAA"
+          }
+        ]
+      },
+      "id": "ed3d78a5-57e8-42ec-a33e-75995a376c7e"
+    },
+    {
+      "click": {
+        "optIn": "button.sp_choice_type_11",
+        "presence": "div#notice"
+      },
+      "domain": "bergfex.at",
+      "cookies": {
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPgejgAPgejgAAGABBENCkCgAAAAAAAAACJwAAAAAAAA.YAAAAAAAAAAA"
+          }
+        ]
+      },
+      "id": "8ac3390c-65c2-4ac7-b0f5-af4d80a84dcf"
+    },
+    {
+      "click": {
+        "optIn": "button.fc-cta-consent",
+        "presence": "div.fc-footer-buttons-container"
+      },
+      "domain": "dnes.bg",
+      "cookies": {},
+      "id": "ed097835-3d75-4864-8cdf-ea8fb19b033c"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "presence": "div#buttons"
+      },
+      "domain": "blesk.cz",
+      "cookies": {
+        "optIn": [],
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPgejgAPgejgAAHABBENCjCgAAAAAAAAAAAAAAAAAACBoAMAAQSCEQAYAAgkEKgAwABBIIZABgACCQQA.YAAAAAAAAAAA"
+          }
+        ]
+      },
+      "id": "64a2e60e-12ed-44b7-9f8d-d402c4db7461"
+    },
+    {
+      "click": {
+        "optIn": "button#onetrust-accept-btn-handler",
+        "presence": "div#onetrust-button-group"
+      },
+      "domain": "mtvuutiset.fi",
+      "cookies": {
+        "optOut": [
+          {
+            "name": "eupubconsent-v2",
+            "value": "CPgeJIgPgeJIgAcABBENCkCgAAAAAAAAAApAAAAAAAAA.YAAAAAAAAAAA"
+          }
+        ]
+      },
+      "id": "13865381-07d5-4a78-a8dd-0b477076ddb8"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "presence": "div.didomi-popup-view"
+      },
+      "domain": "ouest-france.fr",
+      "cookies": {
+        "optIn": [],
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPgejgAPgejgAAHABBENCjCgAAAAAAAAAAAAAAAAAAEhIAMAAQSCDQAYAAgkEIgAwABBIIVABgACCQQyADAAEEgh0AGAAIJBEIAMAAQSCJQAYAAgkEUgAwABBIIA.YAAAAAAAAAAA"
+          }
+        ]
+      },
+      "id": "c144159a-a24e-44be-955a-52a65d745505"
+    },
+    {
+      "click": {
+        "optIn": "button#minf-privacy-accept-btn-screen1-id",
+        "optOut": "button#minf-privacy-open-modal-btn-id",
+        "presence": "div.minf-privacy-rationale"
+      },
+      "domain": "mediaset.it",
+      "cookies": {},
+      "id": "a54d7325-5847-4f20-815f-a938dacd81b4"
+    },
+    {
+      "click": {
+        "optIn": "button#onetrust-accept-btn-handler",
+        "presence": "div#onetrust-button-group"
+      },
+      "domain": "buienradar.nl",
+      "cookies": {
+        "optOut": [
+          {
+            "name": "OptanonConsent",
+            "value": "isGpcEnabled=0&datestamp=Fri+Oct+07+2022+17%3A23%3A59+GMT%2B0300+(Eastern+European+Summer+Time)&version=6.20.0&isIABGlobal=false&hosts=&consentId=4667db01-1d36-4250-8e2f-4b27055c8f3a&interactionCount=1&landingPath=NotLandingPage&groups=C0001%3A1%2CC0002%3A1%2CC0004%3A0%2CC0005%3A0%2CC0003%3A1%2CBG155%3A0"
+          }
+        ]
+      },
+      "id": "f4894df6-01b5-4baf-9cec-ef1218e7df3b"
+    },
+    {
+      "click": {
+        "optIn": "button#onetrust-accept-btn-handler",
+        "presence": "div#onetrust-button-group"
+      },
+      "domain": "tvn24.pl",
+      "cookies": {
+        "optOut": [
+          {
+            "name": "eupubconsent-v2",
+            "value": "CPgeJIgPgeJIgAcABBENCkCgAAAAAH_AACiQJDtf_X__b2_r-_5_f_t0eY1P9_7__-0zjhfdl-8N3f_X_L8X52M7vF36tq4KuR4ku3LBIUdlHOHcTUmw6okVryOsbk2cr7NKJ7PEmnMbOydYGH9_n1_z-ZKY7__vf_7zvneAA75iAGAEAIASQggAgAAABAIAAAOABAAAABIAAAAAgAgAAAAAAAAAAAAAAAAAD994JEAEmGrcQBdmWODNtGEUCIEYVhIdQKACigGFogMIHVwU7K4CfWECABAKAJwIgQ4AowYBAAAJAEhEQEgR4IBAARAIAAQAKhEIAGNgEFgBYGAQACgGhYoxQBCBIQZEBEUpgQFAABQKAEAAAAAAIgAAAAAABAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK1EAAAA.YAAAD_gAAAAA"
+          }
+        ]
+      },
+      "id": "a3353d4d-2632-4bd7-bbd9-354ad6ac4bbd"
+    },
+    {
+      "click": {
+        "optIn": "button#L2AGLb",
+        "optOut": "button#W0wltc",
+        "presence": "div.spoKVd"
+      },
+      "domain": "google.ru",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "CONSENT",
+            "value": "PENDING"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "SOCS",
+            "value": "CAESHAgBEhJnd3NfMjAyMjEwMDQtMF9SQzMaAnJvIAEaBgiA2P2ZBg"
+          }
+        ]
+      },
+      "id": "a2960dbb-fbf8-4ffd-aa00-667b473f4d60"
+    },
+    {
+      "click": {
+        "optIn": "button#onetrust-accept-btn-handler",
+        "optOut": "button#onetrust-reject-all-handler",
+        "presence": "div#onetrust-button-group-parent"
+      },
+      "domain": "oe24.at",
+      "cookies": {},
+      "id": "64729de2-9e46-47d3-9b75-b8d58f0d8e58"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "presence": "div#didomi-popup"
+      },
+      "domain": "rtbf.be",
+      "cookies": {
+        "optOut": [
+          {
+            "name": "didomi_token",
+            "value": "eyJ1c2VyX2lkIjoiMTgzYjJkZWEtMzZiNC02YzExLThhMmItNzRhOWY0YzMzZjQwIiwiY3JlYXRlZCI6IjIwMjItMTAtMDdUMTQ6MzQ6NTEuMTQ3WiIsInVwZGF0ZWQiOiIyMDIyLTEwLTA3VDE0OjM0OjUxLjE0N1oiLCJ2ZW5kb3JzIjp7ImRpc2FibGVkIjpbImdvb2dsZSIsImM6Z29vZ2xlYW5hLTRUWG5KaWdSIl19LCJwdXJwb3NlcyI6eyJkaXNhYmxlZCI6WyJkZXZpY2VfY2hhcmFjdGVyaXN0aWNzIiwiZ2VvbG9jYXRpb25fZGF0YSJdfSwidmVyc2lvbiI6Mn0="
+          }
+        ]
+      },
+      "id": "8362bf12-5c9e-4028-8077-b7194b7aa020"
+    },
+    {
+      "click": {
+        "optIn": "button.fc-cta-consent",
+        "presence": "div.fc-footer-buttons"
+      },
+      "domain": "dnevno.hr",
+      "cookies": {
+        "optIn": [],
+        "optOut": [
+          {
+            "name": "FCCDCF",
+            "value": "%5Bnull%2Cnull%2Cnull%2C%5B%22CPgejgAPgejgAEsABCHRCkCgAAAAAAAAAA6IAAAOhQD2F2K2kKEkfjSUWYAQBCujIEIhUAAAAECBIAAAAUgQAgFIIAgAAlACAAAAABAQAQCAgAQABAAAoACgAAAAAAAQAAAAAAQQAABAAIAAAAAAAAEAQAAIAAQAAAAAAABEhCAAQQQEAAAABAAAAAAAQAAAAAABAAA.YAAAAAAAAAA%22%2C%221~%22%2C%22EA05584B-4C95-44E8-A602-F0B836FF2176%22%5D%2Cnull%2Cnull%2C%5B%5D%5D"
+          }
+        ]
+      },
+      "id": "032bda24-ffad-4283-a36b-e1c1dd0c46d7"
+    },
+    {
+      "click": {
+        "optIn": "button#CybotCookiebotDialogBodyLevelButtonLevelOptinAllowAll",
+        "optOut": "button#CybotCookiebotDialogBodyButtonDecline",
+        "presence": "div#CybotCookiebotDialogBodyButtonsWrapper"
+      },
+      "domain": "bt.dk",
+      "cookies": {},
+      "id": "3b604615-6d14-4ac8-b184-b9421b99a07c"
+    },
+    {
+      "click": {
+        "optIn": "button#save-all-action",
+        "optOut": "button#save-necessary-action",
+        "presence": "div.iOMuvDyuoMKpVRzmevldA3KUmWI2t3RJ"
+      },
+      "domain": "veikkaus.fi",
+      "cookies": {},
+      "id": "afa1eaa5-68fa-4fe8-97f0-3176c0eb6557"
+    },
+    {
+      "click": {
+        "optIn": "button.iubenda-cs-accept-btn",
+        "presence": "div.iubenda-cs-opt-group"
+      },
+      "domain": "3bmeteo.com",
+      "cookies": {
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPgejgAPgejgAB7EVCITChCgAAAAAAAAAAAAAAAQpgGAA4ACWAZ8BHgCVwGCAMfAbmA7YB3IDwQIUgEhILQACAAFwAUABUADIAHIAPABAADAAGUANAA1AB5AEMARQAmABPACqAG8AOYAegA_ACEgEMARIAjgBLACaAFKALcAYYAyABlgDZAHfAPYA-IB9gH7AP8BAwCKQEXARiAjQCOAEpAKCAU8Aq4BcwDFAGiANYAbQA3ABxAD0AHyAQ6AiEBIgCYgEygJ2AUOApEBTQCxQFoALYAXIAu8BeYDBgGGwMjAyQBk4DLgGcgM-AaRA1gDWQG3gN1AcEA4iByYHKAOXAeOA9oCEMELgQvAhyBD0CH4EQwIpAR9Aj-GgOgBcAEMAMgAZYA2YB9gH4AQAAgoBGACngFXgLQAtIBrADqgHyAQ6AiYBFQCRAE7AKRAXIAyMBk4DOQGeAM-AcoBH8RAXAEMAMgAZYA2YB9gH4AQAAjABTwCrgGsAOqAfIBDoCRAE7AKRAXIAyMBk4DOQGfAOUAj-KgLAAUACGAEwALgAjgBlgEcAKvAWgBaQEggJiAWwAuQBeYDIwGcgM8AZ8A3IBygELwI_jICgAQwAmACOAGWARwAq4BWwEnAJiAWiAtgBcgC8wGRgM5AZ4Az4BygELwI_joOAAC4AKAAqABkADkAHwAgABdADAAMoAaABqADwAH0AQwBFACYAE8AKsAXABdADEAGYAN4AcwA9AB-gEMARIAlgBMACaAFGAKUAWIAt4BhAGHAMgAygBogDZAHeAPaAfYB-gD_AIGARSAiwCMQEcAR2AlICVAFBAKeAVcAsUBaAFpgLmAusBeQF6AMUAbQA3ABxADnAHUAPQAfYBDoCIQEVAIvASCAkQBKgCZAE7AKHAU0AqwBYoCygFsALgAXIAu0Bd4C8wF9AMGAYaAx6BkYGSAMnAZUAywBlwDMwGcgM-AaJA0gDSQGlgNVAawA28BuoDiAHFwOTA5QBy4DxwHtAPrAgCBBoCF8EOQQ6Ah6BFICOwEfQI_kIIoACwAKAAZABcADEAGoAQwAmABTACqAFwAMQAZgA3gB6AEcAKUAWIAwgBlADvAH2AP8AigBHACUgFBAKeAVeAtAC0gFzAMUAbQA5wB1AD0AIhASCAkQBJwCVAFNAKsAWKAsoBaIC2AFwALkAXaAyMBk4DOQGeAM-AaIA0kBpYDVQHAAOIAcoA8cCFAELwIdAQ9Aj6BH8lA_AAQAAsACgAGQAOAAfgBgAGIAPAAiABMACqAFwAMQAZoBDAESAI4AUYApQBbgDCAGUANkAd8A-wD8AI4AU8Aq8BaAFpgLmAuoBigDcAHUAPkAfYBDoCJgEVAIvASIAsUBZQC2AF2gLzAZGAycBlgDOQGeAM-AaQA1gBt4DgAHtAQBAgeBCECF4ENQIegRZAj-UgqgALgAoACoAGQAOQAfACCAGAAZQA0ADUAHkAQwBFACYAE8AKQAVQAxABmADmAH6AQwBEgCjAFKALEAW4AwoBkAGUANEAbIA74B9gH6ARYAjEBHAEdAJSAUEAq4BWwC5gF5AMUAbQA3AB6AD7AIdARMAi8BIgCTgE7AKHAVYAsUBaAC2AFwALkAXaAvMBfQDDYGRgZIAycBlgDLgGcgM8AZ9A0gDSYGsAayA28BuoDgoHJgcoA5cB4oDxwHtAQhAheBDMCHQEPQIgARSAjsBH8A"
+          }
+        ]
+      },
+      "id": "2625ca4e-dd77-4e72-a6d0-c959f3575ad8"
+    },
+    {
+      "click": {
+        "optIn": "button#onetrust-accept-btn-handler",
+        "presence": "div#onetrust-button-group-parent"
+      },
+      "domain": "irishtimes.com",
+      "cookies": {
+        "optOut": [
+          {
+            "name": "OptanonConsent",
+            "value": "isGpcEnabled=0&datestamp=Fri+Oct+07+2022+17%3A53%3A49+GMT%2B0300+(Eastern+European+Summer+Time)&version=6.35.0&isIABGlobal=false&consentId=28cbd935-c622-4c34-86a1-6696786e61b8&interactionCount=1&landingPath=NotLandingPage&groups=C0001%3A1%2CC0003%3A0%2CC0002%3A0%2CC0004%3A0%2CC0005%3A0&hosts=H22%3A1%2CH75%3A1%2CH17%3A0%2CH20%3A0%2CH25%3A0%2CH81%3A0%2CH104%3A0%2CH13%3A0%2CH19%3A0%2CH310%3A0%2CH523%3A0%2CH349%3A0%2CH474%3A0%2CH38%3A0%2CH524%3A0%2CH53%3A0%2CH54%3A0%2CH57%3A0%2CH74%3A0%2CH503%3A0%2CH491%3A0%2CH21%3A0%2CH197%3A0%2CH497%3A0%2CH51%3A0%2CH501%3A0%2CH66%3A0%2CH73%3A0&genVendors="
+          }
+        ]
+      },
+      "id": "9deaf5f0-662c-4974-830c-b000ebd53739"
+    },
+    {
+      "click": {
+        "optIn": "button#onetrust-accept-btn-handler",
+        "presence": "div#onetrust-button-group-parent"
+      },
+      "domain": "libertatea.ro",
+      "cookies": {
+        "optOut": [
+          {
+            "name": "eupubconsent-v2",
+            "value": "CPggmm_Pggmm_AcABBENCkCgAAAAAAAAAChQIPtf_X__b2_j-_59f_t0eY1P9_7_v-0zjhfdl-8N2f_X_L8X52M7vF36pq4KuR4ku3LBIQVlHOHcTUmw6okVryPsbk2Mr7NKJ7PEmnMbOydYGH9_n13T-ZKY7___f_7z_v-v___3____7-3f3__p___--_e_V_99zfn9_____9vN___9v-gAAAGBAAQHyhgAID5RAAEB8pAACA_gkABAaEUABANCAfwA.YAAAAAAAAAAA"
+          }
+        ]
+      },
+      "id": "9432df53-89ea-42cb-b28a-884445723581"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "presence": "div#buttons"
+      },
+      "domain": "20minutos.es",
+      "cookies": {
+        "optOut": [
+          {
+            "name": "didomi_token",
+            "value": "eyJ1c2VyX2lkIjoiMTgzYzBlY2ItYmExMS02MDQ2LTgwZDMtYmUyNjcyOTZhOTg5IiwiY3JlYXRlZCI6IjIwMjItMTAtMTBUMDg6MDU6MTAuNzIxWiIsInVwZGF0ZWQiOiIyMDIyLTEwLTEwVDA4OjA1OjEwLjcyMVoiLCJ2ZW5kb3JzIjp7ImRpc2FibGVkIjpbImdvb2dsZSIsImM6dmVuZG9yLXByb21ldGVvIiwiYzpjaXRpc2VydmktWXRnR0RuOUgiLCJjOnZlbmRvci1kb2d0cmFjayJdfSwicHVycG9zZXMiOnsiZGlzYWJsZWQiOlsiZGV2aWNlX2NoYXJhY3RlcmlzdGljcyIsImdlb2xvY2F0aW9uX2RhdGEiXX0sInZlbmRvcnNfbGkiOnsiZGlzYWJsZWQiOlsiZ29vZ2xlIl19LCJ2ZXJzaW9uIjoyLCJhYyI6IkFBQUEuQUFBQSJ9"
+          }
+        ]
+      },
+      "id": "bb2b02a7-2627-4c94-a329-5013551aedc0"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "presence": "div#buttons"
+      },
+      "domain": "sudinfo.be",
+      "cookies": {
+        "optOut": [
+          {
+            "name": "didomi_token",
+            "value": "eyJ1c2VyX2lkIjoiMTgzYzBlZWUtMjEwNi02N2Q5LTkzZjYtNWNlNWFlYWY5YzM3IiwiY3JlYXRlZCI6IjIwMjItMTAtMTBUMDg6MDc6MzAuNDkwWiIsInVwZGF0ZWQiOiIyMDIyLTEwLTEwVDA4OjA3OjMwLjQ5MFoiLCJ2ZW5kb3JzIjp7ImRpc2FibGVkIjpbInR3aXR0ZXIiLCJnb29nbGUiLCJjOnF1YWxpZmlvLTlKUWpKSmhCIiwiYzp5b3V0dWJlIiwiYzpob3RqYXIiLCJjOmluc3RhZ3JhbSIsImM6Y2hhcnRiZWF0IiwiYzpncmFwZXNob3QiLCJjOndpc2Vwb3BzIiwiYzp2aWRlb3BsYXphIiwiYzpoZWxwaGVyby05VEJmWHR5dCIsImM6c2VsbGlnZW50LUdnd0RXZG5oIiwiYzpvbmVzaWduYWwtcVYyQ0VwV2oiLCJjOmdvb2dsZWFuYS00VFhuSmlnUiIsImM6cWlvdGEtaFVZSEt3dzIiLCJjOmFpcnNoaXAiLCJjOnBpYW5vIl19LCJwdXJwb3NlcyI6eyJkaXNhYmxlZCI6WyJkZXZpY2VfY2hhcmFjdGVyaXN0aWNzIiwiZ2VvbG9jYXRpb25fZGF0YSIsImdlb19tYXJrZXRpbmdfc3R1ZGllcyIsImdlb19hZHMiLCJjb29raWVzZm8tUUhqV2hLMkciXX0sInZlcnNpb24iOjIsImFjIjoiQUFBQS5BQUFBIn0="
+          }
+        ]
+      },
+      "id": "7aeca59f-133a-4d42-bd80-fdddfff7bc74"
+    },
+    {
+      "click": {
+        "optIn": "button",
+        "presence": "div.gdprcookie"
+      },
+      "domain": "zamunda.net",
+      "cookies": {
+        "optOut": [
+          {
+            "name": "cookieControlPrefs",
+            "value": "[\"essential\"]"
+          }
+        ]
+      },
+      "id": "03f54762-dc2a-4cf9-bf1b-412a68dbf0db"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "presence": "div#buttons"
+      },
+      "domain": "centrum.cz",
+      "cookies": {
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPgocUAPgocUAAHABBENCjCgAAAAAAAAAATIAAAAAACBoAMAAQSCEQAYAAgkEKgAwABBIIZABgACCQQA.YAAAAAAAAAAA"
+          }
+        ]
+      },
+      "id": "f7c921fa-386d-41d8-afe0-09d04e0ed697"
+    },
+    {
+      "click": {
+        "optIn": "button#onetrust-accept-btn-handler",
+        "presence": "div#onetrust-button-group"
+      },
+      "domain": "gazeta.pl",
+      "cookies": {},
+      "id": "a4740b36-2d68-47cd-9850-ce25081dd3d1"
+    },
+    {
+      "click": {
+        "optIn": "button#onetrust-accept-btn-handler",
+        "optOut": "button#onetrust-reject-all-handler",
+        "presence": "div#onetrust-button-group-parent"
+      },
+      "domain": "hotnews.ro",
+      "cookies": {},
+      "id": "8aa20b4d-ce46-41c4-9f53-2c050df64135"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "presence": "div#buttons"
+      },
+      "domain": "elpais.com",
+      "cookies": {
+        "optOut": [
+          {
+            "name": "didomi_token",
+            "value": "eyJ1c2VyX2lkIjoiMTgzYzBmYjAtMDQ5Mi02ZDhjLTg0NjgtMzRiMTU4ZDRiZTBjIiwiY3JlYXRlZCI6IjIwMjItMTAtMTBUMDg6MjA6MzkuNDk0WiIsInVwZGF0ZWQiOiIyMDIyLTEwLTEwVDA4OjIwOjM5LjQ5NFoiLCJ2ZW5kb3JzIjp7ImRpc2FibGVkIjpbImdvb2dsZSIsInR3aXR0ZXIiXX0sInB1cnBvc2VzIjp7ImRpc2FibGVkIjpbImRldmljZV9jaGFyYWN0ZXJpc3RpY3MiLCJnZW9sb2NhdGlvbl9kYXRhIiwiZGF0YV9zaGFyaW5nIl19LCJ2ZXJzaW9uIjoyLCJhYyI6IkFBQUEuQUFBQSJ9"
+          }
+        ]
+      },
+      "id": "ed9b78fc-c23e-494b-9d2a-c837abf424d0"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "presence": "div#buttons"
+      },
+      "domain": "sinoptik.bg",
+      "cookies": {
+        "optOut": [
+          {
+            "name": "_pbjs_userid_consent_data",
+            "value": "689651363488201"
+          }
+        ]
+      },
+      "id": "cdfbb69b-a204-43ae-b9a7-0feb54f9106b"
+    },
+    {
+      "click": {
+        "optIn": "button",
+        "presence": "div.fucking-eu-cookies"
+      },
+      "domain": "bazos.cz",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "fucking-eu-cookies",
+            "value": "1"
+          }
+        ]
+      },
+      "id": "2b4d7564-cd3d-4271-834d-426d592cddbe"
+    },
+    {
+      "click": {
+        "optIn": "button.fc-cta-consent",
+        "presence": "div.fc-footer-buttons-container"
+      },
+      "domain": "seiska.fi",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "cto_bundle",
+            "value": "gA4hOV8yR0czTUFpN1RvZDBrdUd4Mjdnc2Vid2padkl5dFdRS1pVMG91SGlCamJlUGtxUU9sdyUyQjQyUE94VzBibDVacWhFampRR0d4V3YwcVU1VEk1Q1o4NjFXN1ppU3hYTTAwdThhT29SVFNNaElwM1hWalZCVXlEamFrQmlxeXY3UXlpZVRSSUNQOTZFNkVHeVpod0NTS3F0dyUzRCUzRA"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "FCCDCF",
+            "value": "%5Bnull%2Cnull%2Cnull%2C%5B%22CPgocUAPgocUAEsABCFICkCgAAAAAAAAAApAAAAQWQD2F2q2kKEkfjSUWYgURCurIEIhcAAAAEKBoAAAAUgQAgFIMIgABlACEAAAABAQAQCAgAQABAAAoICgAAAAAAAAAAAAAAQQACBAAIAAAAAAAAEAQAAoAAQAAAAAAABEhCAAQQAEIAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAIAAA.YAAAAAAAAAA%22%2C%221~%22%2C%22AC745442-DC8E-42A9-AAB5-970367496CBA%22%5D%2Cnull%2Cnull%2C%5B%5D%5D"
+          }
+        ]
+      },
+      "id": "57d6c05c-44b6-4e02-91b6-ef91cca6a311"
+    },
+    {
+      "click": {
+        "optIn": "button.gdpr-lmd-button--main",
+        "presence": "div.gdpr-lmd-wall__content"
+      },
+      "domain": "lemonde.fr",
+      "cookies": {},
+      "id": "9182a6f2-eddc-43b2-991e-8b3a204e4eac"
+    },
+    {
+      "click": {
+        "optIn": "button#_cpmt-accept",
+        "presence": "div#_cpmt-buttons"
+      },
+      "domain": "gazzetta.it",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPgpnrRPgpnrRFzABBFRBdCgAP_AAH_AAAqIH7Nf_X__b3_n-_79__t0eY1f9_7_v-0zjhfdt-8N2f_X_L8X_2M7vF36pr4KuR4ku3bBIQdtHOncTUmx6olVrTPsbk2Mr7NKJ7Pkmnsbe2dYGH9_n93T_ZKZ7______7________________________-_____9____________wP2AJMNS-AC7EscGSaNKoUQIQrCQ6AUAFFAMLRNYQMrgp2VwEeoIGACE1ARgRAgxBRiwCAAQCAJCIgJADwQCIAiAQAAgBUgIQAEbAILACwMAgAFANCxAigCECQgyOCo5TAgIkWignsrAEou9jTCEMosAKBR_RUYCJQggWBkJCwcxgAA"
+          }
+        ]
+      },
+      "id": "4aa16185-4697-4bc4-b0b5-6afecd64c77f"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "presence": "div#buttons"
+      },
+      "domain": "sport.es",
+      "cookies": {},
+      "id": "0886f67c-0a25-405d-aa9d-72cfdaa399b1"
+    },
+    {
+      "click": {
+        "optIn": "button#gdpr-consent-banner-accept-button",
+        "presence": "div.gdpr-consent-modal"
+      },
+      "domain": "2dehands.be",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "cto_bundle",
+            "value": "6LSRR19vaVVnVjdSWHlPZmtPSzM0bmIlMkJ4OVVFVDNDNm9MMTZ3WVYzUHhsTm1OTjZpZ0poOEl1bVNFWGp5VXB5ZSUyQnJ3RENpM25WN1QzeUxQckxjSmlyelhydmdRRzg1RlpmRXNsaE1tSGZDSXEzJTJGNG5MbEF1ZiUyQkZTVWgxbnR1bGQzRW0wdFpyakhINVM4SXpkbk9PJTJGdXQ4SE1nJTNEJTNE"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "rbzid",
+            "value": "9B4wIoP8rsa+1YSv57XFo/uUSV+sZUNn9YHPdzFdQ9vj99CJquEXFnM9Icin8eAg4s61utnrutr/pbB4VnjxhdpAYo9E4+hvwG1ldnRSNgrgH67CESdXEK8ui4aWrxYINvbBwjSgrFpKg31SfphpXBJ+Rn2DUGX8HsLFm6gd0Erqfm1LGPuP0KbsVo+XacG5fDA4pTQ8CorfGyH8TTH9hIe9NozfxGveJAX7VoPFDpH7+Vmj9DlOUQ4kVR80UIhm"
+          }
+        ]
+      },
+      "id": "7626055f-07fb-4e9b-8df3-73c0b4b2e1de"
+    },
+    {
+      "click": {
+        "optIn": "button.fc-cta-consent",
+        "presence": "div.fc-footer-buttons-container"
+      },
+      "domain": "novilist.hr",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "FCCDCF",
+            "value": "%5Bnull%2Cnull%2Cnull%2C%5B%22CPgocUAPgocUAEsABBHRCkCoAP_AAH_AAA6IIqNd_H__bX9n-f7_6ft0eY1f9_r37uQzDhfNs-8F3L_W_LwX_2E7NF36tq4KmR4ku1LBIQNtHMnUDUmxaokVrzHsak2cpyNKJ7BkknsZe2dYGFtPm5lD-QKZ7_5_d3f52T_9_9v-39z33913v3d_3-_12Ljd_599H_v_fR_bc_Kft_5-_8v8_____3_BFNjv43bra_s7x-d9R5ujRGr6v5S_VwGYcI4tGjgE5fy35WAf6wnYAu3RpWBEyPElmpAJCAhIAk4gKk2LREipaIZBACTFEBpBDYMkgtjLywKAgkh8XEoKwBTPL3NxIzvOSW_HdN_2_uW63uut-Jl63wcuhcbP3Fto21t7wAjLBwThmpJWvFpn53_-mZwAAA.cAAAD_gAAAA%22%2C%221~2052.2056.2064.20.2068.2069.2070.2072.2074.2084.39.2088.2090.43.46.2103.55.57.2107.2109.61.2115.70.2124.2130.83.2133.2137.89.2140.93.2145.2147.2150.108.2156.117.2166.122.124.2177.131.135.2183.136.2186.143.144.147.149.2202.2205.159.162.2213.167.2216.171.2219.2220.2222.2224.2225.2234.192.196.202.2253.211.2264.218.228.230.2279.2282.239.241.2292.2299.2305.259.2309.2312.266.2315.2316.272.2322.2325.2328.2331.2334.286.2335.2336.2337.291.2343.2354.2357.2358.2359.311.317.2370.322.323.2373.326.327.2376.2377.338.2387.2392.2394.2400.2403.2405.2406.358.2407.2411.2414.2415.367.2416.2418.370.371.2425.2427.385.389.2440.394.397.2447.2453.407.2459.2461.413.2462.415.2465.2468.2472.424.2477.430.2481.2484.436.2486.2488.2493.445.2496.2497.449.2498.2499.2501.453.2506.2510.2511.2517.469.2526.2527.482.2532.2534.486.2535.491.2542.494.495.501.503.2552.505.2555.2559.2563.2564.2567.2568.2569.522.2571.523.2572.2575.2577.2583.2584.540.2589.2596.2597.550.2601.2602.2604.2605.559.2608.2609.2610.2612.2614.568.2618.2621.574.2624.576.2628.2629.584.2633.2634.587.2636.591.2642.2643.2645.2646.2647.2650.2651.2652.2656.2657.2658.2660.2661.2669.2670.624.2677.2681.2684.2686.2687.2689.2690.2695.2698.2707.2713.2714.2729.2739.2767.2768.2770.2772.733.2784.737.2787.2791.2792.2793.745.2798.2801.2805.2812.2813.2814.2816.2817.2818.2821.2822.2824.2827.2830.2831.2832.2834.787.2838.2839.2840.2844.2846.798.2847.2849.2850.802.803.2852.2854.2856.2860.2862.2863.2865.817.2867.820.2869.821.2872.2873.2874.2875.827.2876.829.2878.2880.2881.2882.2883.2884.2886.2887.839.2888.2889.2891.2893.2894.2895.2897.2898.2900.2901.2908.2909.2911.2912.864.2913.2914.867.2916.2917.2918.2919.2920.2922.874.2923.2924.2927.2929.2930.2931.2935.2939.2940.2941.2942.2947.899.2949.2950.904.2956.2961.2962.2963.2964.2965.2966.2968.2970.922.2972.2973.2974.2975.2979.931.2980.2981.2983.2985.2986.938.2987.2991.2994.2995.2997.2999.3000.3002.3003.3005.3008.3009.3010.3012.3016.3017.3018.3019.3023.3024.3025.979.3028.981.3030.985.3034.3037.3038.3043.3045.3048.1003.3052.3053.3055.3058.3059.3063.3065.3066.3068.3070.1024.3072.3073.3074.1027.3075.3076.3077.3078.1031.1033.1040.3089.3090.3093.1046.3094.3095.1048.3097.1051.3099.1053.3104.3106.3109.3112.1067.3117.3118.3119.3120.3124.3126.3127.3128.3130.1085.3133.3135.3136.3137.1092.1095.1097.3145.1099.3149.3150.3151.3153.3154.1107.3155.3162.3163.3167.3172.3173.1127.3180.3182.1135.3183.3184.3185.3187.3188.3189.3190.1143.3194.3196.1149.3197.1152.3209.1162.3210.3211.1166.3214.3215.3217.1171.3219.3222.3223.3225.3226.3227.3228.3230.3231.3232.1186.3234.3235.1188.3236.3237.3238.3240.3241.3244.3245.1201.3250.3251.1205.3253.3254.3257.1211.3260.1215.3266.1220.3268.3270.3272.1226.1227.1230.3281.3286.3288.3290.3292.3293.3295.3296.1252.3300.1268.1270.3322.1276.1284.1286.1290.1301.1307.1312.1345.1356.1364.1365.1375.1403.1415.1416.1419.1440.1442.1449.1455.1456.1465.1495.1512.1516.1525.1540.1548.1555.1558.1564.1570.1577.1579.1583.1584.1591.1603.1616.1638.1651.1653.1660.1665.1667.1677.1678.1682.1697.1699.1703.1712.1716.1720.1721.1725.1732.1745.1750.1753.1765.1769.1782.1786.1800.1808.1810.1825.1827.1832.1838.1840.1842.1843.1845.1859.1866.1870.1878.1880.1889.1898.1899.1911.1917.1929.1942.1944.1958.1962.1963.1964.1967.1968.1969.1978.2003.2007.2008.2012.2027.2035.2039.2044.2047%22%2C%221B663699-8278-41B8-9A73-C98E45F0FDDF%22%5D%2Cnull%2Cnull%2C%5B%5D%5D"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "UA_ADS",
+            "value": "{\"/21617374708/novilist.hr/home_break_v2\":5,\"/21617374708/novilist.hr/content_v1\":5,\"/21617374708/novilist.hr/content_v2\":5,\"/21617374708/novilist.hr/content_v3\":5,\"/21617374708/novilist.hr/content_parallax_v1\":5,\"/21617374708/novilist.hr/home_break_v1\":5,\"/21617374708/novilist.hr/home_break_v3\":5,\"/21617374708/novilist.hr/home_sidebar_v1\":4,\"/21617374708/novilist.hr/home_sidebar_v2\":5,\"/21617374708/novilist.hr/home_sidebar_v3\":5,\"/21617374708/novilist.hr/home_wallpaper_left\":4,\"/21617374708/novilist.hr/home_wallpaper_right\":4,\"/21617374708/novilist.hr/life_content_v1\":5,\"/21617374708/novilist.hr/life_content_v2\":5,\"/21617374708/novilist.hr/life_content_v3\":5,\"/21617374708/novilist.hr/life_sidebar_v1\":5,\"/21617374708/novilist.hr/life_home_top_v1\":5,\"/21617374708/novilist.hr/life_wallpaper_left\":5,\"/21617374708/novilist.hr/life_wallpaper_right\":5,\"/21617374708/novilist.hr/gospodarstvo_billboard_v1\":5,\"/21617374708/novilist.hr/vijesti_billboard_v1\":5,\"/21617374708/novilist.hr/gallery_v1\":5,\"/21617374708/novilist.hr/gallery_v2\":5,\"/21617374708/novilist.hr/gallery_v3\":5,\"/21617374708/novilist.hr/gallery_inarticle_v1\":5,\"/21617374708/novilist.hr/gallery_inarticle_v2\":5,\"/21617374708/novilist.hr/gallery_inarticle_v3\":5,\"/21617374708/novilist.hr/ticker_desktop_v1\":4,\"/21617374708/novilist.hr/sport_content_v1\":5,\"/21617374708/novilist.hr/sport_parallax_v1\":5,\"/21617374708/novilist.hr/home_top_v1\":3,\"/21617374708/novilist.hr/teads_v1\":5}"
+          }
+        ]
+      },
+      "id": "4e504e16-4d0e-4a57-bb3c-b6349d1a5653"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "presence": "div#buttons"
+      },
+      "domain": "iprima.cz",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "didomi_token",
+            "value": "eyJ1c2VyX2lkIjoiMTgzYzExNTEtYzFmNS02NGIxLTg3ZjEtZTA0ZWViMjBjZjdjIiwiY3JlYXRlZCI6IjIwMjItMTAtMTBUMDg6NDg6NTcuNDI5WiIsInVwZGF0ZWQiOiIyMDIyLTEwLTEwVDA4OjQ4OjU3LjQyOVoiLCJ2ZW5kb3JzIjp7ImVuYWJsZWQiOlsiZ29vZ2xlIiwiYzp5YWhvby1hZC1leGNoYW5nZSIsImM6eWFob28tYW5hbHl0aWNzIiwiYzp5YWhvby1hZC1tYW5hZ2VyLXBsdXMiLCJjOnBlcmZvcm1pb2N6IiwiYzpnb29nbGVhbmEtNFRYbkppZ1IiLCJjOmZ0dnByaW1hLUdNRTNLRkdSIl19LCJwdXJwb3NlcyI6eyJlbmFibGVkIjpbImZ0di1wcmltYSJdfSwidmVyc2lvbiI6MiwiYWMiOiJDWG1BRUFGa0V2SUEuQUFBQSJ9"
+          }
+        ]
+      },
+      "id": "bd685e6d-3260-4529-a4e6-acb116325ad4"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "presence": "div#buttons"
+      },
+      "domain": "subito.it",
+      "cookies": {
+        "optIn": [],
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPgprWUPgprWUAKAmBENCkCgAAAAAH_AAAwIAAASIAJMNW4gC7MscGbQMIoEQIwrCQqgUAEFAMLRAYAODgp2VgE-sIEACAUARgRAhwBRgQCAAASAJCIAJAiwQAAAiAQAAgARCIQAMDAILACwMAgABANAxRCgAECQgyICApTAgKgSCA1sqEEoLpDTCAOssAKCRGxUACIJARWAAICwcAwRICViwQJMUb5ACMEKAUSoVqIAAAAA.YAAAAAAAAAAA"
+          }
+        ]
+      },
+      "id": "a912a9dd-1723-4ad0-b15b-98ad02fab66e"
+    },
+    {
+      "click": {
+        "optIn": "button.css-hxv78t",
+        "presence": "div.qc-cmp2-summary-buttons"
+      },
+      "domain": "irishmirror.ie",
+      "cookies": {
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPgocUAPgocUAAHABBENCjCgAAAAAGLAABCYAAARvgZAALAAqABcADIAHAAPAAggBiAGQANAAeABFACZAE8AUAAuABiADMAGgAOYAegA_ACEAEcAJgATQApQBbgDKAHUAP0AgYBCACLAEcALmAXUAwIB2wDyAIvASCAkQBJwCYgFNgLzAZYA1gB-4EQAI3gCCIAMAAQSCFQAYAAgkEQgAwABBIIZABgACCQQ.YAAADFgAAAAA"
+          }
+        ]
+      },
+      "id": "3cab2d97-d9eb-4254-97aa-441ad90ada69"
+    },
+    {
+      "click": {
+        "optIn": "button#onetrust-accept-btn-handler",
+        "presence": "div#onetrust-button-group"
+      },
+      "domain": "funda.nl",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "id5id",
+            "value": "%7B%22created_at%22%3A%222022-10-10T09%3A05%3A22.067866336Z%22%2C%22id5_consent%22%3Atrue%2C%22original_uid%22%3A%22ID5*TED7Uj2yncaRpTWIesDpWyaoJW_Kid_1FSZGtH1y64wmhGS40qpqKNKQmHBMlLcsJoayOku42cj2TdS2ZmIqciaI8Eqlws5qyzMupxfb_K8mi7GVAusLvjL5WRRVBa_SJpFp49Im_rvhIDknMqYicCaSNnagwsKAI0hBRZsNoPImkxSpsmOFRLeTMyHJ73Q9Jpd7RhT_TpIacpFYe6TGSiabaZVM2-ZyhJICllVIxlEmn-6pm1W1ifXo-DapHwwnJqAV3cNdbUEofvPG1GPLRyahuVjzwoQ1712LPhILuY0moi3bSFZls0N5iYmgpiTuJqUD5zldzHoSupzvhqpjtg%22%2C%22universal_uid%22%3A%22ID5*FLLvBfejjZSjfF9AKvOnznlm5cbjAt0UMlNvoljUIuQmhAnCWVFgCcD3j9FzOuLUJobY3AdpvLtnPMz4ZwT5MCaI9qu4l6VIPgCCyoY_P1wmi8iMLd8dVQh01A70DYhkJpGahlwIVcpiQQi1hyR1NSaSTNFA75FUAbAXMXPhmgYmk7r3uUpcF99vtC3u6U_2Jpeuj7_Y06ZgNpMCTPd7nCabt1vqRmLazUX_uX81WOMmn2jRYJnKwP5_9H6sSdfuJqAikB83E5bN2bTbvEJS9SahJr3GC_JoWKgssFtEm-wmoouram0bORHZ0R1KhMOzJqWJ5BEencwgm5pAYknnDw%22%2C%22signature%22%3A%22ID5_ASGcVyddVm24lmFNERHo3cqakLznG1_MV9F_W476mlB_l0XXtOSCN-FbvxjDwQc5oRzDNirG6Us0eMz_mnsUiko%22%2C%22link_type%22%3A1%2C%22cascade_needed%22%3Afalse%2C%22privacy%22%3A%7B%22jurisdiction%22%3A%22gdpr%22%2C%22id5_consent%22%3Atrue%7D%7D"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "eupubconsent-v2",
+            "value": "CPgoB8gPgoB8gAcABBENCkCgAAAAAAAAAChQGgNF7S5dRGPCWG58ZtskOQQPoNSMJgQjABaJAmgJwAKAMIQCkmASPATgBAACCAYAKAIBAANkGAAAAQAAQAAAAAGEQAAABAIIICIAgBIBCAAIAAQAAAAQQAAAgEACAEAAkgAAAIIAQEAABAAAAeEgMgAIAAWABUADIAHAAPAAgABkADQAHgARAAmABPACqAFgAN4AjgBLgDDAH6ARwAlIC5AF5gMkCADwAHgAfABaAFAALYAfwBFgC-AGoAQMAxQCLwEegJWAU2GAGAALACeAFQALYAbwBFgDUAJaAYoA6gCLwFNhoAYAXIC0ALSAuQQAJAAWAE8ALYAbwBFgDUAJaAYoBF4iACAuQUAvAAaAA-ADAAMgAiABYADEAJgAXIAvADEAG0APEAfwCCAEKAI4ASYAoABUACtAFkAMqAagBqwDiAOQAeYBHACTAEtgJ4AnoBSACvwFoAWkAu4BgQDFQGcAZ0A0ABpwDhQH6AfsBAgCPQEggJ3AUQAswBcgC8wF8jAFAAD4AMAAyACIAFgAMQAmABegDCAMQAbYA_gEEAI4ASYAoABUACtAFkAMcAZQA1IBxAHIAPMAjgBLYCeAJ6AUgAr4BdwDFQGcAZ0A0EBpgGnAOEAfsBAgCPQEggJ3AUQAswBeY4A8AAgAB4AFwAPgAtAByAD8AKAAWwAvgBoAD-AI4AWQAvgBqAEDAIQAREAloBWYDAAMCAZkA14CPQErAJiAU2AqYBfQ6BKAAsACoAGQAOAAggBiAGQANAAeAA-ACIAEwAJ4AVQAsABcADEAG-AS4BMACxAGGAMoAaIA3wB-gEWAI4ASmAtAC0gF1AMUAdQBF4CQQFWALkAXmAyQgA6AACAAgABYADQAHgAZABEACwAGMATABNACqAFyALwAxABoADaAG-AP4BAgCLAEcAJMAUAAqABWwCxALIAXwAyoBqAGqAN8AcQA5AB5gEcAJSATgAngBSACsgFfgLQAtIBdwDAAGKAMzAZwBnQDQQGmAacA4QB1ID9AP3AgACBAEegJBATuAogBZgC2QFyAL5JQFAAEAALAAyABwAGIAPAAiABMACqAFwAMQAjgBlAEcgLQAtIBdQDFAHUAReAvMkAMAAuADkAKgAbwBZAC-AGoAS0ArIBrwErAL2KQGQAFgAVAAyABwAEEAMQAyABoADwAIgATAAngBVACwAGIAWIAygBogD9AIsARwAlICLwFyALzAZIUALgAXAA-AC0AHIAPwAqABfADeAI4AWQAvgBqAEtAKyAXUAwABigDXgI9ATEApsBUwC-g.YAAAAAAAAAAA"
+          }
+        ]
+      },
+      "id": "671bb8b2-bf05-430e-9de9-5bcbd318dfa2"
+    },
+    {
+      "click": {
+        "optIn": "button.cmp-intro_acceptAll",
+        "presence": "div.cmp-intro_options"
+      },
+      "domain": "businessinsider.com.pl",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "pubconsent",
+            "value": "npa%3D0%26vendorListVersion%3D155%26cmpTid%3D1746213%26publicationVersion%3D773%26customVendorsConsent%3D1"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "adpconsent",
+            "value": "CPgpskOPgpsrAEYACAENCbCgAIAAAH_AAB5YI8QAAR4AJMNW4gC7EscCbQMIoUQIwrCQqgUAEFAMLRBYAODgp2VgE-sIWACAUARgRAhxBRgwCAAQCAJCIAJAiwQCIAiAQAAgARAIQAETAILACwMAgABANCxQCgAECQgyICI5TAgIgSCglsrEEoK9DTCAOssAKDRGxUACJAABSAgJCwcAwRICXiyQJMUb5ACMEKAUSoAA.cAAAAbgAAIAA"
+          }
+        ]
+      },
+      "id": "cfc382a9-9f4d-4c64-9484-bd9e1afa0fdb"
+    },
+    {
+      "click": {
+        "optIn": "button#onetrust-accept-btn-handler",
+        "optOut": "button#onetrust-reject-all-handler",
+        "presence": "div#onetrust-button-group-parent"
+      },
+      "domain": "adevarul.ro",
+      "cookies": {},
+      "id": "e879264e-5e9f-11ed-9b6a-0242ac120002"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "optOut": "button#didomi-notice-disagree-button",
+        "presence": "div#buttons"
+      },
+      "domain": "heureka.sk",
+      "cookies": {},
+      "id": "d37d1568-852f-4363-874d-f3d9286a0fe8"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "presence": "div#buttons"
+      },
+      "domain": "elespanol.com",
+      "cookies": {},
+      "id": "0a539a1a-b40f-44b8-8fda-6a003246e3b7"
+    },
+    {
+      "click": {
+        "optIn": "button.cookiebtn",
+        "presence": "div.button"
+      },
+      "domain": "watson.ch",
+      "cookies": {},
+      "id": "3f8bdfb5-b898-4c25-ad68-6e10dab38e45"
+    },
+    {
+      "click": {
+        "optIn": "button.optanon-allow-all",
+        "presence": "div.optanon-alert-box-button-container"
+      },
+      "domain": "rightmove.co.uk",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "beta_optin",
+            "value": "N:27:-1"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "OptanonConsent",
+            "value": "isIABGlobal=false&datestamp=Mon+Oct+10+2022+12%3A22%3A59+GMT%2B0300+(Eastern+European+Summer+Time)&version=5.11.0&landingPath=NotLandingPage&groups=1%3A1%2C3%3A0%2C4%3A0&consentId=46d31f45-9548-49c1-8ff5-d2df4784f238"
+          }
+        ]
+      },
+      "id": "9319d649-88db-4b21-a276-664cfc9090a7"
+    },
+    {
+      "click": {
+        "optIn": "a.close-accept",
+        "presence": "div.woahbar"
+      },
+      "domain": "theweathernetwork.com",
+      "cookies": {},
+      "id": "3cfb8e27-c0b3-46c0-bee2-f4eef9c2a548"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "presence": "div#buttons"
+      },
+      "domain": "standaard.be",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "cto_bundle",
+            "value": "TD9jQV8yeGlPWXpLV1FqRlFGazRzQnZUV21XWDlXSVFwamF5b3VBbFNNMnFwbnRpeHRHaVI3OWQybnZPTlo0TkI0RkROYnR5cTRTSSUyRndNUTJXVlJ2MGFkMEN5akRYQXBuOWJYY3RZSmhBN1RCbzE2S1BleWZpS3VwZldaRWkxczdPdklPczE0MFFXMkZVeVVwMUZqVVZEMElGUSUzRCUzRA"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPgocUAPgocUAAHABBENCjCgAAAAAAAAAAAAAAAAAAAhoAMAAQSC.YAAAAAAAAAAA"
+          }
+        ]
+      },
+      "id": "e63e6c22-7c70-4a95-bd82-fac8b29e302f"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "presence": "div#buttons"
+      },
+      "domain": "heureka.cz",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "__gfp_64b",
+            "value": "ami8Fhj0W1sUN5pyFjpjJb.YuG4ngtzhrDGLjQkksyH.f7|1665394263"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPgocUAPgocUAAHABBENCjCgAAAAAH_AAATIAAASCAJMNW4gC7EscCbaMIoEQIwrCQ6gUAFFAMLRAYQOrgp2VwE-sIEACAUARgRAhxBRgwCAAACAJCIgJAjwQCIAiAQAAgAVCIQAEbAIKACwMAgAFANCxRigCECQgyICIpTAgIkSCgnsqEEoO9DTCEOssAKDR_xUICJQAhWBEJCwchwRICXiyQLMUb5ACMEKAUSoVoAA.YAAAD_gAAAAA"
+          }
+        ]
+      },
+      "id": "03f2b735-68c6-4405-96f3-580aa2aba016"
+    },
+    {
+      "click": {
+        "optIn": "button.coi-banner__accept",
+        "optOut": "button#declineButton",
+        "presence": "div.coi-button-group"
+      },
+      "domain": "dmi.dk",
+      "cookies": {},
+      "id": "db64d8f2-1d35-4b57-a274-452efbcf2589"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "presence": "div#buttons"
+      },
+      "domain": "lequipe.fr",
+      "cookies": {
+        "optOut": [
+          {
+            "name": "didomi_token",
+            "value": "eyJ1c2VyX2lkIjoiMTgzYzE0MGQtZGQ3OS02MjQ3LWFmMjgtOWNjNDQ2OTUzZjY1IiwiY3JlYXRlZCI6IjIwMjItMTAtMTBUMDk6Mzc6MjkuMTMzWiIsInVwZGF0ZWQiOiIyMDIyLTEwLTEwVDA5OjM3OjI5LjEzM1oiLCJ2ZW5kb3JzIjp7ImVuYWJsZWQiOlsiZ29vZ2xlIiwiYzpwaXhlbGdvb2cteWJiOWQ0QXQiLCJjOm9uZm9jdXMtZVljN3pyV3AiLCJjOmthbWVsZW9vbi1jVHlLZXlLOSIsImM6ZGZwLVQ3VktBaUJQIiwiYzpwcmViaWQtWks1SFFBUGEiLCJjOnBpeGVsdHdpdC1GYU1kdzhNUiIsImM6bWVkaWFtZXRyaS1FNmF0dDk3UCIsImM6Z3JhcGVzaG90IiwiYzpmYWNlYm9vay1Ld3c4UjRFaCIsImM6ZGlkb21pLWFSR0YycnFVIiwiYzphY3BtLVZrUFo4SmU0IiwiYzppbnN0YWdyYW0tSFhVdEdOZVkiLCJjOmZhY2Vib29rYy1hUmQyUHhCUCIsImM6ZGFpbHltb3Rpby1uVlFCajJVQyIsImM6d2Vib3JhbWEtelVuSnFFYWciLCJjOmR5ZHUtYU5keGY0VjgiLCJjOndvbmRlcnB1c2gtWlZ5a0hoR2kiLCJjOnBpeGVsbGluay1meUtGM20zaCIsImM6bWljcm9zb2Z0LVJMNkN5RUJhIiwiYzpnb29nbGVzaWctblA2Ym1GYlEiLCJjOmdpZ3lhLVliV1ZDcFVMIiwiYzpzcGVlZGN1cnYteUY3VjM5R3QiLCJjOmNlZGV4aXMtNERNNDdyZmIiLCJjOm1pbGlicmlzLXJSd2hUR0FxIiwiYzpteWZlZWxiYS1tblJDR1VwSyIsImM6c2VsbGlnZW50LVpncXB5eEZrIiwiYzptZWRpYXJpdGhtLXlaQ2ozakJXIiwiYzphcHBsZS1SV0R0S0piMiIsImM6ZGV2aWNlY2FwLUpaVWNIQkhBIiwiYzpncmFwZXNob3QtdFBwYUdMclIiLCJjOm1pY3Jvc29mdC1hbmFseXRpY3MiLCJjOmF0aW50ZXJuZS1jV1FLSGVKWiIsImM6Z29vZ2xlZmlyLTJwSlFLRW5kIiwiYzphdGludGVybmUtSGdNa2lDSzkiXX0sInB1cnBvc2VzIjp7ImVuYWJsZWQiOlsiYXV0cmVzcHViLU1FN0pBNHRBIiwicHVibGljaXRlLU04R0VpN3p4IiwicGVyc29ubmFsaS1SYjNtd0pDbSIsIm1lc3VyZWRhLVZWcUNxbnFSIiwiYXVkaWVuY2VtLXhlZGVVMmdRIiwiZ2VvbG9jYXRpb25fZGF0YSIsImRldmljZV9jaGFyYWN0ZXJpc3RpY3MiXX0sInZlcnNpb24iOjIsImFjIjoiQVVhQUNBVVkuQUFBQSJ9"
+          }
+        ]
+      },
+      "id": "2f7dbe65-17ef-4c9d-b88b-42b0afe9d4fe"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "optOut": "span.didomi-continue-without-agreeing",
+        "presence": "div#buttons"
+      },
+      "domain": "jofogas.hu",
+      "cookies": {},
+      "id": "c1d7be10-151e-4a66-b83b-31a762869a97"
+    },
+    {
+      "click": {
+        "optIn": "button.sp_choice_type_11",
+        "presence": "div#notice"
+      },
+      "domain": "e24.no",
+      "cookies": {},
+      "id": "c9478690-5957-4203-992c-a86684ace1bf"
+    },
+    {
+      "click": {
+        "optIn": "button.is-primary",
+        "presence": "div.cookie-wrapper"
+      },
+      "domain": "mediaexpert.pl",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "cookies",
+            "value": "1"
+          }
+        ]
+      },
+      "id": "82e304ba-5ca0-457d-8db3-8da8769d032d"
+    },
+    {
+      "click": {
+        "optIn": "a.cmptxt_btn_yes",
+        "presence": "div.cmpboxinner"
+      },
+      "domain": "novosti.rs",
+      "cookies": {
+        "optOut": [
+          {
+            "name": "__cmpconsentx20816",
+            "value": "CPgoB8gPgoB8gAfMwBSRCkCgAAAAAAAAAAigAAAI8gAgI8AA"
+          }
+        ]
+      },
+      "id": "53f117b7-5d9d-4387-8507-95fb64a4da86"
+    },
+    {
+      "click": {
+        "optIn": "a.js-cookies-info-accept",
+        "optOut": "a.js-cookies-info-reject",
+        "presence": "div.cookies-info__buttons"
+      },
+      "domain": "alza.sk",
+      "cookies": {},
+      "id": "93b1a4a4-49e2-4160-98ae-e2311123c7f9"
+    },
+    {
+      "click": {
+        "optIn": "button#onetrust-accept-btn-handler",
+        "optOut": "button#onetrust-reject-all-handler",
+        "presence": "div#onetrust-banner-sdk"
+      },
+      "domain": "ricardo.ch",
+      "cookies": {},
+      "id": "77878915-9cbd-4d9e-aa81-3cb2fc369cf1"
+    },
+    {
+      "click": {
+        "optIn": "button#onetrust-accept-btn-handler",
+        "presence": "div#onetrust-button-group-parent"
+      },
+      "domain": "viaplay.dk",
+      "cookies": {},
+      "id": "c15977a2-e270-432b-b7b6-65d60a62d6f6"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "optOut": "span.didomi-continue-without-agreeing",
+        "presence": "div.didomi-popup-container"
+      },
+      "domain": "meteofrance.com",
+      "cookies": {},
+      "id": "30d3f850-392b-4630-8a67-67483f4e87fa"
+    },
+    {
+      "click": {
+        "optIn": "button#onetrust-accept-btn-handler",
+        "presence": "div#onetrust-button-group"
+      },
+      "domain": "aib.ie",
+      "cookies": {},
+      "id": "1a4d4854-6f8c-4d53-8b93-92885a37e6cc"
+    },
+    {
+      "click": {
+        "optIn": "button#onetrust-accept-btn-handler",
+        "presence": "div#onetrust-button-group-parent"
+      },
+      "domain": "otomoto.pl",
+      "cookies": {
+        "optIn": [],
+        "optOut": [
+          {
+            "name": "eupubconsent-v2",
+            "value": "CPgqEWmPgqEceAcABBENCkCgAAAAAH_AAAYgJDtf_X__b2_r-_5_f_t0eY1P9_7__-0zjhfdl-8N3f_X_L8X52M7vF36tq4KuR4ku3LBIUdlHOHcTUmw6okVryPsbk2cr7NKJ7PEmnMbOydYGH9_n1_z-ZKY7___f_7z_v-v___3____7-3f3__5___-__e_V__9zfn9_____9vP___9v-_9__________3_7994JEAEmGrcQBdmWODNtGEUCIEYVhIdQKACigGFogMIHVwU7K4CfWECABAKAJwIgQ4AowYBAAAJAEhEQEgR4IBAARAIAAQAKhEIAGNgEFgBYGAQACgGhYoxQBCBIQZEBEUpgQFSJBQb2VCCUH-hphCHWWAFBo_4qEBGsgYrAiEhYOQ4IkBLxZIHmKN8gBGCFAKJUK1EAAAA.YAAAD_gAAAAA"
+          }
+        ]
+      },
+      "id": "dfe19707-8434-4ee5-9632-dec5a872ea18"
+    },
+    {
+      "click": {
+        "optIn": "a#CybotCookiebotDialogBodyButtonAccept",
+        "optOut": "a#CybotCookiebotDialogBodyButtonDecline",
+        "presence": "div#CybotCookiebotDialogBodyButtons"
+      },
+      "domain": "mondo.rs",
+      "cookies": {},
+      "id": "f1502dfd-a03c-4ca1-ab5d-488b2e09b644"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "presence": "div#buttons"
+      },
+      "domain": "abc.es",
+      "cookies": {
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPgocUAPgocUAAHABBENCjCgAAAAAAAAAAAAAAAAAAEhIAMAAQSCFQAYAAgkEMgAwABBIINABgACCQQiADAAEEgh0AGAAIJBEIAMAAQSCJQAYAAgkEUgAwABBIIA.YAAAAAAAAAAA"
+          }
+        ]
+      },
+      "id": "8622b7d2-8efa-4a6c-a9ee-4066d9a7accc"
+    },
+    {
+      "click": {
+        "optIn": "button.noticeButton",
+        "presence": "div.noticeActions"
+      },
+      "domain": "cbc.ca",
+      "cookies": {},
+      "id": "f69ced41-7e20-4b39-84a2-0fa62e7df3ef"
+    },
+    {
+      "click": {
+        "optIn": "button#truste-consent-button",
+        "optOut": "button#truste-consent-required",
+        "presence": "div#truste-consent-buttons"
+      },
+      "domain": "weather.com",
+      "cookies": {},
+      "id": "8ef284ed-21d1-4825-8068-34ac22e5232d"
+    },
+    {
+      "click": {
+        "optIn": "button.fc-primary-button",
+        "presence": "div.fc-footer-buttons"
+      },
+      "domain": "bazar.bg",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "FCNEC",
+            "value": "%5B%5B%22AKsRol-gSkl2tNYwSI_gqUlfrxHvd5IABRHAc08FlwNT8zL7XHge8zFzefSxrx3ChJ-jst1vRlDTf-D3NhLBidEG3BbGmVvP9Qgfp1KMzN-sBRvCtiCPlZopmGp9IU5jt0Jm4SY5Ojjm4PhwwuKodjGTcJSHQz_-Vg%3D%3D%22%5D%2Cnull%2C%5B%5D%5D"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "FCCDCF",
+            "value": "%5Bnull%2Cnull%2Cnull%2C%5B%22CPgocUAPgocUAEsABCBGCkCgAAAAAAAAAAIwAAAOhQD2F2K2kKEkfjSUWYAQBCujKEIhUAAAAECBIAAAAUgQAgFIIAgAAlACAAAAABAQAQCAgAQABAAAoACgAAAAAAAAAAAAAAQQAABAAIAAAAAAAAEAQAAIAAQAAAAAAABEhCAAQQAEAAAAAAAAAAAAAAAAAAABAAA%22%2C%221~%22%2C%222259601D-A3C8-4B02-80F2-AF6ADF73E293%22%5D%2Cnull%2Cnull%2C%5B%5D%5D"
+          }
+        ]
+      },
+      "id": "a7cbcc28-fa3f-46cc-9010-613e5031549b"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "presence": "div#buttons"
+      },
+      "domain": "denik.cz",
+      "cookies": {
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPgocUAPgocUAAHABBENCjCgAAAAAAAAAATIAAAAAACBoAMAAQSCEQAYAAgkEKgAwABBIIZABgACCQQA.YAAAAAAAAAAA"
+          }
+        ]
+      },
+      "id": "b21f8621-a640-4511-a925-592a3626b004"
+    },
+    {
+      "click": {
+        "optIn": "button#almacmp-modalConfirmBtn",
+        "presence": "div.almacmp-controls"
+      },
+      "domain": "etuovi.com",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "gravitoData",
+            "value": "{\"TCString\":\"CPgocUAPgocUABUAJAFICkCsAP_AAH_AAApAHxQIwAFgAQAAqABkADwAIAAZAA0AB8AEQAI4ATwAqABbADmAH4AQUAhACFAEwANEAbIBCACIgEWAJEATsAtIBgQDFAHUAP0AmQBbIC8wHxAfFAdAAWABUADIAHgAQAAyABoAD4AIgATwA5gB-AEIAJgAaIA2QCEAERAIsASIAtIBgQDFAGfAOoAmQBeYDBAHxAEhIB4ACwAKgAZAA8ACAAGQANAAiABPADmAH4AQgA2QDFALzDQAgBsgFpEQAQBsioAQBaQF5jIAIC8x0BQABYAFQAMgAgABkADQAHwARAAngBzAD8AJgAaIA2QCLAFpAMUAdQBMgC8yEAUABYAGQC0gGKAOoSgEAALAAyAEQAbIBaQDFAHUAXmUgHgALAAqABkAEAAMgAaABEACeAHMAPwA0QBsgEWAMUAvMAAA.YAAAAAAAAMAA\",\"NonTCFVendors\":[{\"id\":1,\"name\":\"Facebook\",\"consent\":true},{\"id\":3,\"name\":\"Google\",\"consent\":true},{\"id\":4,\"name\":\"Chartbeat\",\"consent\":true},{\"id\":5,\"name\":\"Giosg\",\"consent\":true},{\"id\":6,\"name\":\"Hotjar\",\"consent\":true},{\"id\":7,\"name\":\"Qualifio\",\"consent\":true},{\"id\":8,\"name\":\"Questback\",\"consent\":true},{\"id\":9,\"name\":\"Twitter\",\"consent\":true},{\"id\":10,\"name\":\"Wordpress\",\"consent\":true},{\"id\":15,\"name\":\"Linkedin\",\"consent\":true},{\"id\":16,\"name\":\"Microsoft\",\"consent\":true},{\"id\":17,\"name\":\"OneSignal\",\"consent\":true},{\"id\":18,\"name\":\"AppCues\",\"consent\":true},{\"id\":19,\"name\":\"Vimeo\",\"consent\":true},{\"id\":21,\"name\":\"Finnchat\",\"consent\":true},{\"id\":22,\"name\":\"Lekane\",\"consent\":true},{\"id\":23,\"name\":\"Zendesk\",\"consent\":true},{\"id\":24,\"name\":\"Serviceform\",\"consent\":true},{\"id\":25,\"name\":\"Smilee\",\"consent\":true},{\"id\":26,\"name\":\"Calendly\",\"consent\":true},{\"id\":27,\"name\":\"Apple\",\"consent\":true},{\"id\":28,\"name\":\"Cavai\",\"consent\":true},{\"id\":29,\"name\":\"Selligent\",\"consent\":true}]}"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "gravitoData",
+            "value": "{\"TCString\":\"CPgocUAPgocUABUAJAFICkCgAAAAAAAAAApAAAAPigAAEhIB4ACwAKgAZAA8ACAAGQANAAiABPADmAH4AQgA2QDFALzDQAgBsgFpEQAQBsioAQBaQF5jIAIC8x0BQABYAFQAMgAgABkADQAHwARAAngBzAD8AJgAaIA2QCLAFpAMUAdQBMgC8yEAUABYAGQC0gGKAOoSgEAALAAyAEQAbIBaQDFAHUAXmUgHgALAAqABkAEAAMgAaABEACeAHMAPwA0QBsgEWAMUAvMA.YAAAAAAAAIAA\",\"NonTCFVendors\":[{\"id\":1,\"name\":\"Facebook\",\"consent\":false},{\"id\":3,\"name\":\"Google\",\"consent\":false},{\"id\":4,\"name\":\"Chartbeat\",\"consent\":false},{\"id\":5,\"name\":\"Giosg\",\"consent\":false},{\"id\":6,\"name\":\"Hotjar\",\"consent\":false},{\"id\":7,\"name\":\"Qualifio\",\"consent\":false},{\"id\":8,\"name\":\"Questback\",\"consent\":false},{\"id\":9,\"name\":\"Twitter\",\"consent\":false},{\"id\":10,\"name\":\"Wordpress\",\"consent\":false},{\"id\":15,\"name\":\"Linkedin\",\"consent\":false},{\"id\":16,\"name\":\"Microsoft\",\"consent\":false},{\"id\":17,\"name\":\"OneSignal\",\"consent\":false},{\"id\":18,\"name\":\"AppCues\",\"consent\":false},{\"id\":19,\"name\":\"Vimeo\",\"consent\":false},{\"id\":21,\"name\":\"Finnchat\",\"consent\":false},{\"id\":22,\"name\":\"Lekane\",\"consent\":false},{\"id\":23,\"name\":\"Zendesk\",\"consent\":false},{\"id\":24,\"name\":\"Serviceform\",\"consent\":false},{\"id\":25,\"name\":\"Smilee\",\"consent\":false},{\"id\":26,\"name\":\"Calendly\",\"consent\":false},{\"id\":27,\"name\":\"Apple\",\"consent\":false},{\"id\":28,\"name\":\"Cavai\",\"consent\":false},{\"id\":29,\"name\":\"Selligent\",\"consent\":false}]}"
+          }
+        ]
+      },
+      "id": "a2cc4223-39e8-4e02-804b-fa9eb4a4ce65"
+    },
+    {
+      "click": {
+        "optIn": "button.css-k8o10q",
+        "presence": "div.qc-cmp2-summary-buttons"
+      },
+      "domain": "newsit.gr",
+      "cookies": {},
+      "id": "25dd408a-0a98-4e93-992c-abd320255cd1"
+    },
+    {
+      "click": {
+        "optIn": "a#startsiden-gdpr-disclaimer-confirm",
+        "presence": "div#startsiden-gdpr-disclaimer"
+      },
+      "domain": "startsiden.no",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "startsiden-gdpr-disclaimer",
+            "value": "true"
+          }
+        ]
+      },
+      "id": "00e9de62-0fc4-4266-8e8c-106da3a624c0"
+    },
+    {
+      "click": {
+        "optIn": "button#onetrust-accept-btn-handler",
+        "presence": "div#onetrust-button-group-parent"
+      },
+      "domain": "sport.pl",
+      "cookies": {
+        "optIn": [],
+        "optOut": [
+          {
+            "name": "eupubconsent-v2",
+            "value": "CPgoB8gPgoB8gAcABBENCkCgAAAAAH_AAAYgAAASIAJMNW4gC7MscGbaMIoEQIwrCQ6gUAFFAMLRAYQOrgp2VwE-sIEACAUATgRAhwBRgwCAAASAJCIgJAjwQCAAiAQAAgAVCIQAMbAILACwMAgAFANCxRigCECQgyICIpTAgKkSCg3sqEEoP9DTCEOssAKDR_xUICNZAxWBEJCwchwRICXiyQPMUb5ACMEKAUSoVqIAAAAA.YAAAD_gAAAAA"
+          }
+        ]
+      },
+      "id": "f96bdcd0-3185-479f-b21c-379fa03e2daa"
+    },
+    {
+      "click": {
+        "optIn": "button.css-1tydlop",
+        "presence": "div.qc-cmp2-summary-buttons"
+      },
+      "domain": "noticiasaominuto.com",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "cto_bundle",
+            "value": "PDyJa19mWnBqMkU1ak53VGlxS1VpalhwVGZ2bXRXVm5HZ3NxNDBTYWhTM24lMkJDZk1CV09SdndPbzR0RWhERERFYWdQMnhiWUlwVng4QWpqVDJza05Ld01lUjJKb1owNG1LVGkyM3JCdjd2NFFVZ0FwY2hXeU9vd2g4UGphTUZ1bXZ5TnElMkY"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPgocUAPgocUAAKAsBPTCkCgAAAAAH_AAB6YAAASIAJMNW4gC7MscGbQMIoEQIwrCQqgUAEFAMLRAYAODgp2VgE-sIEACAUARgRAhwBRgQCAAASAJCIAJAiwQAAAiAQAAgARCIQAMDAILACwMAgABANAxRCgAECQgyICIpTAgKgSCA1sqEEoLpDTCAOssAKCRGxUACIJARWAAICwcAwRICViwQJMUb5ACMEKAUSoVqIAAAAA.YAAAAAAAAAAA"
+          }
+        ]
+      },
+      "id": "cbd5d112-8190-40d1-ad4a-6e8f6aa17c5a"
+    },
+    {
+      "click": {
+        "optIn": "button.css-47sehv",
+        "presence": "div.qc-cmp2-summary-buttons"
+      },
+      "domain": "telegraf.rs",
+      "cookies": {
+        "optIn": [],
+        "optOut": [
+          {
+            "name": "UA_ADS",
+            "value": "{\"/43680898/telegraf.rs/gallery_desktop_v1\":5,\"/43680898/telegraf.rs/gallery_300x250_v1\":5,\"/43680898/telegraf.rs/home_970x250_v1\":5,\"/43680898/telegraf.rs/banner_300x600_v2\":4,\"/43680898/telegraf.rs/banner_300x250_v3\":5,\"/43680898/telegraf.rs/banner_300x250_v4\":5,\"/43680898/telegraf.rs/content_v1\":5,\"/43680898/telegraf.rs/content_v2\":5,\"/43680898/telegraf.rs/content_v3\":5,\"/43680898/telegraf.rs/gallery_v1\":5,\"/43680898/telegraf.rs/gallery_v2\":5,\"/43680898/telegraf.rs/gallery_v3\":5,\"/43680898/telegraf.rs/esport_content_v1\":5,\"/43680898/telegraf.rs/esport_content_v2\":5,\"/43680898/telegraf.rs/esport_content_v3\":5}"
+          }
+        ]
+      },
+      "id": "6785afba-648d-46cf-8633-3d9c433c79ff"
+    },
+    {
+      "click": {
+        "optIn": "button#CybotCookiebotDialogBodyLevelButtonLevelOptinAllowAll",
+        "optOut": "button#CybotCookiebotDialogBodyButtonDecline",
+        "presence": "div#CybotCookiebotDialogBodyButtons"
+      },
+      "domain": "profesia.sk",
+      "cookies": {},
+      "id": "346b2412-6aef-4eea-b2d5-8b74b4917f4a"
+    },
+    {
+      "click": {
+        "optIn": "button.css-1ysvf99",
+        "presence": "div.qc-cmp2-summary-buttons"
+      },
+      "domain": "flashback.org",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "cto_bundle",
+            "value": "R_x1OV9FMzZkWlJHTzhKcWp6U2R2aGwxOTdYS2xNdSUyQjBLQUw3bElHMnZNNHp0ekRQTDJYS0Qxa2hFZmtadURMaExuUVVJemxiVVlIWjE5ZE5GV3Vaa21BQzhXN1pxc3NGOTJtREdwOEdFV1RyM3czS0VOVnNLWG8lMkYyNnNLN0dZZ0htVng"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPgocUAPgocUAAKAsBSVCkCgAAAAAH_AACQgAAASIAJMNW4gC7MscGbQMIoEQIwrCQqgUAEFAMLRAYAODgp2VgE-sIEACAUARgRAhwBRgQCAAASAJCIAJAiwQAAAiAQAAgARCIQAMDAILACwMAgABANAxRCgAECQgyICIpTAgKgSCA1sqEEoLpDTCAOssAKCRGxUACIJARWAAICwcAwRICViwQJMUb5ACMEKAUSoVqIAAAAA.YAAAAAAAAAAA"
+          }
+        ]
+      },
+      "id": "14d5418a-4df6-4dfe-9c81-fd07669e0f9c"
+    },
+    {
+      "click": {
+        "optIn": "button#cmp-btn-accept",
+        "presence": "div#cmp-consent"
+      },
+      "domain": "wetter.com",
+      "cookies": {},
+      "id": "8e274753-a1ee-4e02-b131-fa937ab10aea"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "presence": "div#buttons"
+      },
+      "domain": "gva.be",
+      "cookies": {
+        "optIn": [],
+        "optOut": [
+          {
+            "name": "didomi_token",
+            "value": "eyJ1c2VyX2lkIjoiMTgzYzFkOTItMWIzOC02ZmRjLTk4MGEtNTRlNDAxZDk1ZDZjIiwiY3JlYXRlZCI6IjIwMjItMTAtMTBUMTI6MjM6MDMuOTgxWiIsInVwZGF0ZWQiOiIyMDIyLTEwLTEwVDEyOjIzOjAzLjk4MVoiLCJ2ZW5kb3JzIjp7ImRpc2FibGVkIjpbImdvb2dsZSIsImM6YWRvYmUtdGFnbWFuYWdlciIsImM6YWdub3BsYXktTXpZY0Y0SEYiLCJjOnB1YnN0YWNrLWlZaGZRM2hRIiwiYzpmYWNlYm9vay1iajRGSkZIVyIsImM6aW5zdGFncmFtIiwiYzpvbW5pdHVyZS1hZG9iZS1hbmFseXRpY3MiLCJjOnJlZC1ieS1zZnIiLCJjOmludGVsbGlhZCIsImM6aW1wYWN0LXJhZGl1cyIsImM6c2hhcnBzcHJpbmciLCJjOmJhdGNoLWpYUHhNTUxOIiwiYzpnb29nbGVhbmEtbjZVTWhKN2UiLCJjOmZhY2Vib29rcC1VRFU4WUtOZiIsImM6Z2V0c2l0ZWNvbi05Q3F6RzdaNiIsImM6ZnJvb21sZS00TnoyWER3TiIsImM6b3B0aW1pemVseS1Zd1ZxOU1XYiIsImM6dndvLWlDZTYyeGQ3IiwiYzptYXRoZXItZWNvbm9taWNzIiwiYzpob3RqYXIteW5GOG1hVVIiLCJjOmlvdGVjaG5vbC15WXBjZnRkeiIsImM6dHdpdHRlci0zdzMzOWNMNiIsImM6ZmFjZWJvb2stY29ubmVjdC16aW1tbyIsImM6aW5zdGFncmFtLWZobXJ4S01XIiwiYzpuZXh0cm9sbC1HRG5wQURHYiIsImM6emFsYW5kby1wVEtZVk1hYiIsImM6dmlydHVhbG1uLUVNQXpNTERXIiwiYzpwbWctWkUyQ3lDRmsiLCJjOm9tbmljb21tZS15UGlqN2dZWiIsImM6aW50ZXJwdWJsaS04SFo4UGZHMyIsImM6Z3NraW5uZXItblVFMzRQMkgiLCJjOnR3aXBlLUNraXROelhEIiwiYzp6ZWJlc3RvZi1jZDdOWUVMTCIsImM6eW91dHViZS1wcGRZd0RLcCIsImM6YWRzYW5kZGEtekdUR1JWSHciLCJjOmJsdWVjb25pYy1tZmNlUFVaOSJdfSwicHVycG9zZXMiOnsiZGlzYWJsZWQiOlsic29jaWFsX21lZGlhIiwidWl0Z2VicmVpZC1BTU4yY2hldCJdfSwidmVuZG9yc19saSI6eyJkaXNhYmxlZCI6WyJnb29nbGUiLCJjOmJsdWVjb25pYy1tZmNlUFVaOSJdfSwicHVycG9zZXNfbGkiOnsiZGlzYWJsZWQiOlsidWl0Z2VicmVpZC1BTU4yY2hldCJdfSwidmVyc2lvbiI6MiwiYWMiOiJBQUFBLkFBQUEifQ=="
+          }
+        ]
+      },
+      "id": "f11cf7cd-4f4d-4e22-b473-9d358d18a601"
+    },
+    {
+      "click": {
+        "optIn": "button#almacmp-modalConfirmBtn",
+        "presence": "div#almacmp-footer--layer1"
+      },
+      "domain": "ampparit.com",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "1p-data-v3",
+            "value": "hVXBcpswFLx3pv%2Fg0dnu2MSuHd9WAgypnVi1aZqWTkcGoai2EQVikmby7x2ctDU9EA4MSLt6y%2B5Denz7ptMhmkw75DxKxmPrbNyLks2oNxyMZE8kieyJ83Es%2Buf9JBlHpHvE5zVe7LNM5Lp8F5n9y%2FihHj%2BcvbxJMu081vhOh6hcHHRpbFGKGvMYkjVblblOVUimIWFLZaIAz3ca4AKuz7aswPI74H0HkMG7534FV4EDP0G3sCv4wBegDzqBw%2BEPsa7quQ3sPbwheIBbMBdOhUsHG58yMF8517hwsC5Q%2BlRx24UXYNnHntONzyaVd4%2FERQxcgwawfXjHkg%2BgBvYQvqqLjBTtwfFxoSB8WJw5cD7CL7Dy%2Fy47S3Bl6mXljU3h3cO59ekQrMIHVcuegAEzjktAgy7%2FaFawalHzXzaHooVyM4eD00IbcCq4O%2Frhw2eT%2Bz7loDdwORYK6mgIh1fhI5Aq%2Bgv25J%2B6OdwMiwAxpwvFJg8Ogpo746yvZh9wZVbKAebAQ%2B3jxqfixZfP%2B0B5qp45Wu6gLiZAHTAJb4FlhT6nRe3pIsBhAeDdDV6uBRCSbkguTbpm7ieZxiYvQjL9%2BhgSHYdkOuiGJBV7eewBV0RyY8z2SIlMWsi0DMm0zO%2FkU%2FcP4%2ByUMTNG7WQrfniKZ7ciLzdSlK2U0Sllpk2hWuHvT%2BGeKX%2BIvBU%2FPsXzO7HTiTatjEmTIYtyI6J2m85PKetKl6VsVzXonzKuTR5nuSyKVl2DhlNznW5lrNN2SsOthY5yU5ikPY9Bw7GrVK60SsWuvU7DM2QZu5OvfEzDsk96L9tDsZq9q9M0un2lsSzr1OO53Iq0vXmtRrd%2FkWksi%2FbcrUa%2Fr2R%2B0JFMTL5vdctqBLna6518RVgjRiZ2Mo13D%2B01Gikiy175ca1GgkwchG5fv5HfSu52Wh03kG5I%2FttMvj2R%2BlR6ej7LtmTa%2Bfrt%2BTk6Pr998%2FQb"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "gravitoData",
+            "value": "{\"TCString\":\"CPgocUAPgocUABUAJAFICkCgAAAAAAAAAApAAAAPigAAEhIB4ACwAKgAZAA8ACAAGQANAAiABPADmAH4AQgA2QDFALzDQAgBsgFpEQAQBsioAQBaQF5jIAIC8x0BQABYAFQAMgAgABkADQAHwARAAngBzAD8AJgAaIA2QCLAFpAMUAdQBMgC8yEAUABYAGQC0gGKAOoSgEAALAAyAEQAbIBaQDFAHUAXmUgHgALAAqABkAEAAMgAaABEACeAHMAPwA0QBsgEWAMUAvMA.YAAAAAAAAIAA\",\"NonTCFVendors\":[{\"id\":1,\"name\":\"Facebook\",\"consent\":false},{\"id\":3,\"name\":\"Google\",\"consent\":false},{\"id\":4,\"name\":\"Chartbeat\",\"consent\":false},{\"id\":5,\"name\":\"Giosg\",\"consent\":false},{\"id\":6,\"name\":\"Hotjar\",\"consent\":false},{\"id\":7,\"name\":\"Qualifio\",\"consent\":false},{\"id\":8,\"name\":\"Questback\",\"consent\":false},{\"id\":9,\"name\":\"Twitter\",\"consent\":false},{\"id\":10,\"name\":\"Wordpress\",\"consent\":false},{\"id\":15,\"name\":\"Linkedin\",\"consent\":false},{\"id\":16,\"name\":\"Microsoft\",\"consent\":false},{\"id\":17,\"name\":\"OneSignal\",\"consent\":false},{\"id\":18,\"name\":\"AppCues\",\"consent\":false},{\"id\":19,\"name\":\"Vimeo\",\"consent\":false},{\"id\":21,\"name\":\"Finnchat\",\"consent\":false},{\"id\":22,\"name\":\"Lekane\",\"consent\":false},{\"id\":23,\"name\":\"Zendesk\",\"consent\":false},{\"id\":24,\"name\":\"Serviceform\",\"consent\":false},{\"id\":25,\"name\":\"Smilee\",\"consent\":false},{\"id\":26,\"name\":\"Calendly\",\"consent\":false},{\"id\":27,\"name\":\"Apple\",\"consent\":false},{\"id\":28,\"name\":\"Cavai\",\"consent\":false},{\"id\":29,\"name\":\"Selligent\",\"consent\":false}]}"
+          }
+        ]
+      },
+      "id": "679d7000-cd04-4c35-bbf8-21263a2ff357"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "presence": "div#buttons"
+      },
+      "domain": "bfmtv.com",
+      "cookies": {
+        "optIn": [],
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPgocUAPgocUAAHABBENCjCgAAAAAAAAAAAAAAAAAAEhIAMAAQSCDQAYAAgkEIgAwABBIIVABgACCQQyADAAEEgh0AGAAIJBEIAMAAQSCJQAYAAgkEUgAwABBIIA.YAAAAAAAAAAA"
+          }
+        ]
+      },
+      "id": "69d72ef6-7881-4b9c-914e-20bb99a9a9ca"
+    },
+    {
+      "click": {
+        "optIn": "button.css-k8o10q",
+        "presence": "div.qc-cmp2-summary-buttons"
+      },
+      "domain": "meteo.gr",
+      "cookies": {
+        "optIn": [],
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPgocUAPgocUAAKAsAELCkCgAAAAAH_AAAyIAAASIAJMNW4gC7MscGbQMIoEQIwrCQqgUAEFAMLRAYAODgp2VgE-sIEACAUARgRAhwBRgQCAAASAJCIAJAiwQAAAiAQAAgARCIQAMDAILACwMAgABANAxRCgAECQgyICIpTAgKgSCA1sqEEoLpDTCAOssAKCRGxUACIJARWAAICwcAwRICViwQJMUb5ACMEKAUSoVqIAAAAA.YAAAAAAAAAAA"
+          }
+        ]
+      },
+      "id": "8cffbd7c-cb54-46bb-9e84-4395001479fc"
+    },
+    {
+      "click": {
+        "optIn": "button.css-k8o10q",
+        "presence": "div#qc-cmp2-ui"
+      },
+      "domain": "videa.hu",
+      "cookies": {
+        "optIn": [],
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPgocUAPgocUAAKAsBHUCkCgAAAAAH_AAA6gAAASIAJMNW4gC7MscGbQMIoEQIwrCQqgUAEFAMLRAYAODgp2VgE-sIEACAUARgRAhwBRgQCAAASAJCIAJAiwQAAAiAQAAgARCIQAMDAILACwMAgABANAxRCgAECQgyICIpTAgKgSCA1sqEEoLpDTCAOssAKCRGxUACIJARWAAICwcAwRICViwQJMUb5ACMEKAUSoVqIAAAAA.YAAAAAAAAAAA"
+          }
+        ]
+      },
+      "id": "6fed31af-f6d2-4452-88ef-8f2ca61c6f19"
+    },
+    {
+      "click": {
+        "optIn": "a#startsiden-gdpr-disclaimer-confirm",
+        "presence": "div#startsiden-gdpr-disclaimer"
+      },
+      "domain": "abcnyheter.no",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "startsiden-gdpr-disclaimer",
+            "value": "true"
+          }
+        ]
+      },
+      "id": "f1001929-c1ef-400b-a2b4-616554148e3b"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "presence": "div#buttons"
+      },
+      "domain": "filmweb.pl",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "didomi_token",
+            "value": "eyJ1c2VyX2lkIjoiMTgzYzFlNTktNzBjZC02ZDRkLWE2ODItNDg3OGE3OWE4OGIwIiwiY3JlYXRlZCI6IjIwMjItMTAtMTBUMTI6MzY6MzkuNjMyWiIsInVwZGF0ZWQiOiIyMDIyLTEwLTEwVDEyOjM2OjM5LjYzMloiLCJ2ZW5kb3JzIjp7ImVuYWJsZWQiOlsiZ29vZ2xlIiwiYzpkaWRvbWkiLCJjOmhvdGphciIsImM6YWRvY2VhbiIsImM6YW50aWFkYmxvLWV6Q3hrZ3FuIiwiYzphbW5ldC1QQTRxZnpqeiIsImM6ZWZpZ2VuY2UtaXc4d1R4R1QiLCJjOmhhdmFzbWVkaS1tZTJ6S3hKSiIsImM6cGVyZm9ybWFuYy1oQ0V4UnltViIsImM6dmFsdWVtZWRpLU56UlJFaGRMIiwiYzp3YXZlbWFrZXItd0J0VEd6YVoiLCJjOndheXRvZ3Jvdy1SYUJEazNXNCIsImM6b21kc3B6by1DelB4NnRQViIsImM6YXJ0ZWdlbmNlLVpoamtCSEdtIiwiYzptYXRvbW8tTjNnazM3YVQiXX0sInB1cnBvc2VzIjp7ImVuYWJsZWQiOlsiZGV2aWNlX2NoYXJhY3RlcmlzdGljcyIsImdlb2xvY2F0aW9uX2RhdGEiXX0sInZlbmRvcnNfbGkiOnsiZW5hYmxlZCI6WyJnb29nbGUiXX0sInZlcnNpb24iOjIsImFjIjoiQUZtQUNBRmsuQUFBQSJ9"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPgocUAPgocUAAHABBENCjCgAAAAAAAAAB5YAAAAAAAA.YAAAAAAAAAAA"
+          }
+        ]
+      },
+      "id": "e80e6edf-12d0-4512-8252-29fe95c5fde5"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "presence": "div#buttons"
+      },
+      "domain": "expresso.pt",
+      "cookies": {
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPgocUAPgocUAAHABBENCjCgAAAAAH_AAAAAAAASCAJMNW4gC7EscCbaMIoEQIwrCQ6gUAFFAMLRAYQOrgp2VwE-sIEACAUARgRAhxBRgwCAAACAJCIgJAjwQCIAiAQAAgAVCIQAEbAIKACwMAgAFANCxRigCECQgyICIpTAgIkSCgnsqEEoO9DTCEOssAKDR_xUICJQAhWBEJCwchwRICXiyQLMUb5ACMEKAUSoVoAA.YAAAD_gAAAAA"
+          }
+        ]
+      },
+      "id": "15b5f9fa-832f-4a9d-ab4a-4e98db289a6d"
+    },
+    {
+      "click": {
+        "optIn": "a#cookieAccept",
+        "presence": "div#cookieContent"
+      },
+      "domain": "publi24.ro",
+      "cookies": {},
+      "id": "8d64659e-ece2-476d-a1c6-eec9e4070647"
+    },
+    {
+      "click": {
+        "optIn": "button.fc-cta-consent",
+        "presence": "div.fc-footer-buttons"
+      },
+      "domain": "hitta.se",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "FCNEC",
+            "value": "%5B%5B%22AKsRol90yizMRNu1QYr1M51YlMPWpRXSGPYNlX8tz4lkWNVqjfmyG9Ucv9sxpp0C577xS83oCpMlN1dbrEjEoCaEC30h0KdVyX795WA8OxmDPrwEhIN7dZ2qOAoDIl2A7qXs-99hGORN2RmgN2_lYcFlbWToe8149Q%3D%3D%22%5D%2Cnull%2C%5B%5D%5D"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "FCCDCF",
+            "value": "%5Bnull%2Cnull%2Cnull%2C%5B%22CPgocUAPgocUAEsABCSVCkCgAAAAAAAAACQgAAAQWQLyEyogkKEINDaESYIERCsjKEIBUBAEAAKRAAAAAQgQAgFoAAAABhAAEAAAABAQAQCAAAQAAAAAIIAAAAAAAAAAAEAAAAAQAAAAAAAgAAAAAAAAAAAoAAAAAAAAAABAACAAAQAAAAAAAABAAAAAAAAAAAABAAAAAAAAAIAAAAAAAAAIAAA.YAAAAAAAAAA%22%2C%221~%22%2C%2273EC6D84-3F9A-4BD6-AB03-44C5FD76291B%22%5D%2Cnull%2Cnull%2C%5B%5D%5D"
+          }
+        ]
+      },
+      "id": "1998c717-cd3a-48a0-a9f3-67f790f98879"
+    },
+    {
+      "click": {
+        "optIn": "button.orejime-Notice-saveButton",
+        "optOut": "button.orejime-Notice-declineButton",
+        "presence": "div.orejime-Notice"
+      },
+      "domain": "belgium.be",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "fedconsent",
+            "value": "{\"essential\":true,\"functional\":true,\"matomo\":true}"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "fedconsent",
+            "value": "{\"essential\":true,\"functional\":true,\"matomo\":false}"
+          }
+        ]
+      },
+      "id": "98fcb883-013a-4858-a181-28c87e399c42"
+    },
+    {
+      "click": {
+        "optIn": "button#onetrust-accept-btn-handler",
+        "presence": "div#onetrust-button-group-parent"
+      },
+      "domain": "novini.bg",
+      "cookies": {
+        "optOut": [
+          {
+            "name": "eupubconsent-v2",
+            "value": "CPgoB8gPgoB8gAcABBENCkCgAAAAAABAAAYgJDtf_X__b2_r-_5_f_t0eY1P9_7__-0zjhfdl-8N3f_X_L8X52M7vF36tq4KuR4ku3LBIUdlHOHcTUmw6okVryPsbk2cr7NKJ7PEmnMbOydYGH9_n1_z-ZKY7___f_7z_v-v___3____7-3f3__5___-__e_V__9zfn9_____9vP___9v-_9__________3_7994JEAEmGrcQBdmWODNtGEUCIEYVhIdQKACigGFogMIHVwU7K4CfWECABAKAJwIgQ4AowYBAAAJAEhEQEgR4IBAARAIAAQAKhEIAGNgEFgBYGAQACgGhYoxQBCBIQZEBEUpgQFSJBQb2VCCUH-hphCHWWAFBo_4qEBGsgYrAiEhYOQ4IkBLxZIHmKN8gBGCFAKJUK1EAAAA.YAAAAAgAAAAA"
+          }
+        ]
+      },
+      "id": "f133993c-9ca3-4b1d-a5f9-65fd1d480a58"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "presence": "div#buttons"
+      },
+      "domain": "csfd.cz",
+      "cookies": {
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPgocUAPgocUAAHABBENCjCgAAAAAAAAAATIAAAAAACBoAMAAQSCEQAYAAgkEKgAwABBIIZABgACCQQA.YAAAAAAAAAAA"
+          }
+        ]
+      },
+      "id": "f9855a34-3c76-4ada-9d76-abefa27fc33e"
+    },
+    {
+      "click": {
+        "optIn": "button#onetrust-accept-btn-handler",
+        "presence": "div#onetrust-consent-sdk"
+      },
+      "domain": "hbomax.com",
+      "cookies": {},
+      "id": "b938786b-f0fc-41f0-9c42-54533888ac74"
+    },
+    {
+      "click": {
+        "optIn": "button#popin_tc_privacy_button_2",
+        "presence": "div#popin_tc_privacy_container_button"
+      },
+      "domain": "credit-agricole.fr",
+      "cookies": {
+        "optIn": [],
+        "optOut": [
+          {
+            "name": "TC_PRIVACY",
+            "value": "1@006%7C86%7C3315@@@1665406595598%2C1665406595598%2C1680958595598@"
+          }
+        ]
+      },
+      "id": "850ca0e7-372f-4c9f-bfbd-76d38a076cf7"
+    },
+    {
+      "click": {
+        "optIn": "button.css-k8o10q",
+        "presence": "div.qc-cmp2-summary-buttons"
+      },
+      "domain": "sport-fm.gr",
+      "cookies": {
+        "optOut": []
+      },
+      "id": "d88020d5-47d0-4926-8375-d279870f1663"
+    },
+    {
+      "click": {
+        "optIn": "button.css-47sehv",
+        "presence": "div.qc-cmp2-summary-buttons"
+      },
+      "domain": "espreso.co.rs",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "_gat_tstTracker",
+            "value": "1"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "addtl_consent",
+            "value": "1~"
+          }
+        ]
+      },
+      "id": "ed6379a2-717a-4571-9a81-abb0c5b29098"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "presence": "div#buttons"
+      },
+      "domain": "lavanguardia.com",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "_gaexp",
+            "value": "GAX1.2.xtsxuGDPTIy7Vr77OFtdeQ.19342.1"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPgrvQAPgrvQAAHABBENCkCgAAAAAAAAAAiQAAAAAAEhIAMAAQSIDQAYAAgkQIgAwABBIgVABgACCRAyADAAEEiB0AGAAIJEEIAMAAQSIJQAYAAgkQUgAwABBIgA.YAAAAAAAAAAA"
+          }
+        ]
+      },
+      "id": "fb30107f-4845-4150-844c-adadf690acc2"
+    },
+    {
+      "click": {
+        "optIn": "button.sp_choice_type_11",
+        "presence": "div.psi-container"
+      },
+      "domain": "svd.se",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPgrvQAPgrvQAAGABCENCkCgAAAAAAAAACJwAAAAAAAA.YAAAAAAAAAAA"
+          }
+        ]
+      },
+      "id": "53ff0950-4e4b-47ca-a0ed-03c8ce311260"
+    },
+    {
+      "click": {
+        "optIn": "button.css-78i25x",
+        "presence": "div.qc-cmp2-summary-buttons"
+      },
+      "domain": "mirror.co.uk",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "_tt_enable_cookie",
+            "value": "1"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "addtl_consent",
+            "value": "1~"
+          }
+        ]
+      },
+      "id": "21593dac-f469-4206-87d9-044e6d69404b"
+    },
+    {
+      "click": {
+        "optIn": "button#onetrust-accept-btn-handler",
+        "presence": "div#onetrust-consent-sdk"
+      },
+      "domain": "espn.com",
+      "cookies": {
+        "optIn": [],
+        "optOut": [
+          {
+            "name": "block.check",
+            "value": "true%7Cfalse"
+          }
+        ]
+      },
+      "id": "01613932-0aa7-4a94-aa47-4cb8be7e2ca9"
+    },
+    {
+      "click": {
+        "optIn": "button#accept-recommended-btn-handler",
+        "optOut": "button#confirm-choices-handler",
+        "presence": "div#ot-content"
+      },
+      "domain": "dhl.de",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "s_cc",
+            "value": "true"
+          }
+        ]
+      },
+      "id": "6dddbd1c-6c99-4085-abf7-8aa15d230701"
+    },
+    {
+      "click": {
+        "optIn": "a.js-cookies-info-accept",
+        "optOut": "a.js-cookies-info-reject",
+        "presence": "div.cookies-info__buttons"
+      },
+      "domain": "alza.cz",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "CBARIH",
+            "value": "1"
+          }
+        ]
+      },
+      "id": "c7a067c4-a365-4497-a990-c042545dfd6c"
+    },
+    {
+      "click": {
+        "optIn": "button#onetrust-accept-btn-handler",
+        "optOut": "button#onetrust-reject-all-handler",
+        "presence": "div#onetrust-consent-sdk"
+      },
+      "domain": "disneyplus.com",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "_tt_enable_cookie",
+            "value": "1"
+          }
+        ]
+      },
+      "id": "a3b0e77d-a7fe-4f38-8015-e368c67ecbbf"
+    },
+    {
+      "click": {
+        "optIn": "button#onetrust-accept-btn-handler",
+        "presence": "div#onetrust-consent-sdk"
+      },
+      "domain": "suomi24.fi",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "cto_bidid",
+            "value": "8Au-w190RUNLcGZQQ3hSUldmQ1VjTSUyRkV5R1RHSnFWb3VIcjY2ekJMMmolMkJpUFNPdHdrZlN0bnlZc1RYMUFXR1FVbDVuTUo5c0I4ZHlvQlYyRCUyRlNkdlk4N2dxQSUzRCUzRA"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "_pbjs_userid_consent_data",
+            "value": "6683316680106290"
+          }
+        ]
+      },
+      "id": "82de7a39-a9d8-4b8d-85c5-20117854c4d7"
+    },
+    {
+      "click": {
+        "optIn": "button.css-ofc9r3",
+        "presence": "div.qc-cmp2-summary-buttons"
+      },
+      "domain": "car.gr",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "policy",
+            "value": "[\"performance\",\"advertising\",\"essential\"]"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "addtl_consent",
+            "value": "1"
+          }
+        ]
+      },
+      "id": "690ce1d3-e595-4181-a109-8f55c1039c81"
+    },
+    {
+      "click": {
+        "optIn": "button.css-k8o10q",
+        "presence": "div.qc-cmp2-summary-buttons"
+      },
+      "domain": "femina.hu",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "inx_checker2",
+            "value": "1"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "addtl_consent",
+            "value": "1~"
+          }
+        ]
+      },
+      "id": "d1b9f7af-26d3-4f1b-812c-9f8cf41da900"
+    },
+    {
+      "click": {
+        "optIn": "a#truste-consent-button",
+        "optOut": "a#truste-consent-required2",
+        "presence": "div#truste-consent-buttons"
+      },
+      "domain": "poste.it",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "cmapi_cookie_privacy",
+            "value": "permit 1,2,3"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "cmapi_cookie_privacy",
+            "value": "permit 1 required"
+          }
+        ]
+      },
+      "id": "450e91f1-22ee-4718-9e98-05f831adfeff"
+    },
+    {
+      "click": {
+        "optIn": "button#onetrust-accept-btn-handler",
+        "presence": "div#onetrust-consent-sdk"
+      },
+      "domain": "rtlnieuws.nl",
+      "cookies": {},
+      "id": "71f3ddcd-c8fd-4ec8-8299-130528c9ee4f"
+    },
+    {
+      "click": {
+        "optIn": "button#onetrust-accept-btn-handler",
+        "presence": "div#onetrust-consent-sdk"
+      },
+      "domain": "playtech.ro",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "_pbjs_userid_consent_data",
+            "value": "2855715574697352"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "adptset_0046",
+            "value": "1"
+          }
+        ]
+      },
+      "id": "3000889a-0084-4e1a-855b-004f06d08fa4"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "presence": "div#buttons"
+      },
+      "domain": "idealista.com",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "datadome",
+            "value": "sZfpq36xMSymU6KsXE4Uw.uJTyi9DR8GESgHFSykSOuSlJ2IOoZKOp6K8hBdy0fwAy8l-0PZfE7pbfb8C3UNA.J4xl0YQWlHHmt~BbX_t4Kc2XG-t5FNJ5E-4mUPtiU"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPgrvQAPgrvQAAHABBENCkCgAAAAAAAAAAAAAAAAAAEBoAMAAQSIJQAYAAgkQUgAwABBIghABgACCRA6ADAAEEiAkAGAAIJEDIAMAAQSIFQAYAAgkQAA.YAAAAAAAAAAA"
+          }
+        ]
+      },
+      "id": "ea251a19-3809-4dde-b16c-5558ee213cc2"
+    },
+    {
+      "click": {
+        "optIn": "button.as-js-optin",
+        "presence": "div.as-oil-l-wrapper-layout-max-width"
+      },
+      "domain": "tagesanzeiger.ch",
+      "cookies": {
+        "optIn": [],
+        "optOut": [
+          {
+            "name": "oil_data",
+            "value": "{%22opt_in%22:true%2C%22version%22:%221.2.5-RELEASE%22%2C%22localeVariantName%22:%22de_01%22%2C%22localeVariantVersion%22:1%2C%22customPurposes%22:[]%2C%22consentString%22:%22BPgtAGPPgtAGPBQABBDECKAAAABCVY_KfQrC0oWQ3LTh5AAkALqlgRiFSEAIHYRE4AIRZUACSAEggHMoyUBIA8RAAERATIJABBgQEAISkAOAAIAgIpACEAgYAJAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAf____3____8A%22%2C%22configVersion%22:0}"
+          }
+        ]
+      },
+      "id": "c9ea0470-beac-43b9-aed1-d77042592d83"
+    },
+    {
+      "click": {
+        "optIn": "button.sp_choice_type_11",
+        "presence": "div#notice"
+      },
+      "domain": "focus.de",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "cto_bundle",
+            "value": "P1yJ-19lM2JWV2xlOUlaZngwWmlNQm5uUFdOcWZvYmRFQmxuc2ZJUXdyZXJrVSUyQm9jUlpYRUlPcEdJcEVCa2w1eWdJM3I4NGtkc1piSUpneEhubmlWT3NoRkdBaFR1bWNmbVZEUVd6Z2R0bHhtJTJCOFBNZTk3dnM1cE1Id0k0a3RTMFdpb0k"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPgrvQAPgrvQAAjABBENCkCgAAAAAAAAACJwAAAAAAAA.YAAAAAAAAAAA"
+          }
+        ]
+      },
+      "id": "3e629e6f-a447-4651-9073-a36c8a4956a5"
+    },
+    {
+      "click": {
+        "optIn": "button#almacmp-modalConfirmBtn",
+        "presence": "div.almacmp-controls"
+      },
+      "domain": "kauppalehti.fi",
+      "cookies": {
+        "optIn": [],
+        "optOut": [
+          {
+            "name": "gravitoData",
+            "value": "{\"TCString\":\"CPgrvQAPgrvQABUAJAFICkCgAAAAAAAAAApAAAAPigOgALAAqABkADwAIAAZAA0AB8AEQAJ4AcwA_ACEAEwANEAbIBCACIgEWAJEAWkAwIBigDPgHUATIAvMBggD4gCQkA8ABYAFQAMgAeABAADIAGgARAAngBzAD8AIQAbIBigF5hoAQA2QC0iIAIA2RUAIAtIC8xkAEBeY6AoAAsACoAGQAQAAyABoAD4AIgATwA5gB-AEwANEAbIBFgC0gGKAOoAmQBeZCAKAAsADIBaQDFAHUJQCAAFgAZACIANkAtIBigDqALzKQDwAFgAVAAyACAAGQANAAiABPADmAH4AaIA2QCLAGKAXmAAA.YAAAAAAAAIAA\",\"NonTCFVendors\":[{\"id\":1,\"name\":\"Facebook\",\"consent\":false},{\"id\":3,\"name\":\"Google\",\"consent\":false},{\"id\":4,\"name\":\"Chartbeat\",\"consent\":false},{\"id\":5,\"name\":\"Giosg\",\"consent\":false},{\"id\":6,\"name\":\"Hotjar\",\"consent\":false},{\"id\":7,\"name\":\"Qualifio\",\"consent\":false},{\"id\":8,\"name\":\"Questback\",\"consent\":false},{\"id\":9,\"name\":\"Twitter\",\"consent\":false},{\"id\":10,\"name\":\"Wordpress\",\"consent\":false},{\"id\":15,\"name\":\"Linkedin\",\"consent\":false},{\"id\":16,\"name\":\"Microsoft\",\"consent\":false},{\"id\":17,\"name\":\"OneSignal\",\"consent\":false},{\"id\":18,\"name\":\"AppCues\",\"consent\":false},{\"id\":19,\"name\":\"Vimeo\",\"consent\":false},{\"id\":21,\"name\":\"Finnchat\",\"consent\":false},{\"id\":22,\"name\":\"Lekane\",\"consent\":false},{\"id\":23,\"name\":\"Zendesk\",\"consent\":false},{\"id\":24,\"name\":\"Serviceform\",\"consent\":false},{\"id\":25,\"name\":\"Smilee\",\"consent\":false},{\"id\":26,\"name\":\"Calendly\",\"consent\":false},{\"id\":27,\"name\":\"Apple\",\"consent\":false},{\"id\":28,\"name\":\"Cavai\",\"consent\":false},{\"id\":29,\"name\":\"Selligent\",\"consent\":false}]}"
+          }
+        ]
+      },
+      "id": "abb44f4b-bc8a-49bf-8f8c-204fe33806e9"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "optOut": "button#didomi-notice-disagree-button",
+        "presence": "div#buttons"
+      },
+      "domain": "francetvinfo.fr",
+      "cookies": {
+        "optOut": []
+      },
+      "id": "a9c6681d-65d3-4df0-970c-1cdd4aab6e5f"
+    },
+    {
+      "click": {
+        "optIn": "button.css-1j8kkja",
+        "presence": "div.qc-cmp2-summary-buttons"
+      },
+      "domain": "news247.gr",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "_gat_UA-482127-5",
+            "value": "1"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "addtl_consent",
+            "value": "1~"
+          }
+        ]
+      },
+      "id": "1b1bdbb4-089c-45dc-9d42-e87a1fa85882"
+    },
+    {
+      "click": {
+        "optIn": "button.iubenda-cs-accept-btn",
+        "optOut": "button.iubenda-cs-reject-btn",
+        "presence": "div.ubl-cst__btns"
+      },
+      "domain": "libero.it",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "cto_bundle",
+            "value": "5jZ-f19NNTIlMkJUWUJwNDBlYk9hcmJTMnJHT1BoeHF2dXFkUkZJWmtpOGJaQTZaWHBKR1dvazhjREx0VzZCNzVFUWFQSVdHTndiJTJGJTJGdDFFOHFBZk9yalhMSXM1QlZ3OXhqM1ZhSVclMkZEelkwVjExQ0t3WlZYSmJ1JTJGSmx2NlB4QUpmd0xWcDk"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "HPtestAB",
+            "value": "4"
+          }
+        ]
+      },
+      "id": "4e4fa6fd-4412-431a-8e1b-b7266920436a"
+    },
+    {
+      "click": {
+        "optIn": "a#CybotCookiebotDialogBodyLevelButtonLevelOptinAllowAll",
+        "optOut": "a#CybotCookiebotDialogBodyLevelButtonLevelOptinDeclineAll",
+        "presence": "div#CybotCookiebotDialogBodyLevelButtonLevelOptinAllowallSelectionWrapper"
+      },
+      "domain": "rip.ie",
+      "cookies": {
+        "optIn": [],
+        "optOut": [
+          {
+            "name": "CookieConsent",
+            "value": "{stamp:%27aQlJVTwi41tewItmxlt/w7TRvv2UDwd39lOxJC/s1TG9dFvEWjL4jQ==%27%2Cnecessary:true%2Cpreferences:false%2Cstatistics:false%2Cmarketing:false%2Cver:1%2Cutc:1665481193123%2Cregion:%27ro%27}"
+          }
+        ]
+      },
+      "id": "051ccd77-b9b3-4558-9c27-5293d8d735f4"
+    },
+    {
+      "click": {
+        "optIn": "button#onetrust-accept-btn-handler",
+        "presence": "div#onetrust-consent-sdk"
+      },
+      "domain": "viaplay.no",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "_tt_enable_cookie",
+            "value": "1"
+          }
+        ]
+      },
+      "id": "c4b8af6b-5e97-4214-badd-67f716d3e5b6"
+    },
+    {
+      "click": {
+        "optIn": "button.cmp-intro_acceptAll",
+        "presence": "div.cmp-intro_options"
+      },
+      "domain": "medonet.pl",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "pubconsent",
+            "value": "npa%3D0%26vendorListVersion%3D155%26cmpTid%3D1746213%26publicationVersion%3D773%26customVendorsConsent%3D1"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "adpconsent",
+            "value": "CPgtEwDPgtE8ZEYACAENCbCgAIAAAAAAAB5YI8QAAR4AJMNW4gC7EscCbQMIoUQIwrCQqgUAEFAMLRBYAODgp2VgE-sIWACAUARgRAhxBRgwCAAQCAJCIAJAiwQCIAiAQAAgARAIQAETAILACwMAgABANCxQCgAECQgyICI5TAgIgSCglsrEEoK9DTCAOssAKDRGxUACJAABSAgJCwcAwRICXiyQJMUb5ACMEKAUSoAA.cAAAAbgAAIAA"
+          }
+        ]
+      },
+      "id": "09e39fcc-7a38-4679-9493-a320ed08c34a"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "presence": "div#buttons"
+      },
+      "domain": "idealista.pt",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "didomi_token",
+            "value": "eyJ1c2VyX2lkIjoiMTgzYzY3MGUtYWMxZS02OGEyLTg0OGQtZGQ5N2E2ZWIzOWVmIiwiY3JlYXRlZCI6IjIwMjItMTAtMTFUMDk6NDc6MTQuNzU3WiIsInVwZGF0ZWQiOiIyMDIyLTEwLTExVDA5OjQ3OjE0Ljc1N1oiLCJ2ZW5kb3JzIjp7ImVuYWJsZWQiOlsiZ29vZ2xlIiwiYzptaXhwYW5lbCIsImM6YWJ0YXN0eS1MTGtFQ0NqOCIsImM6aG90amFyIiwiYzpiZWFtZXItSDd0cjdIaXgiLCJjOmFwcHNmbHllci1HVVZQTHBZWSIsImM6dGVhbGl1bWNvLURWRENkOFpQIiwiYzppZGVhbGlzdGEtN0dudDY0ekYiLCJjOmlkZWFsaXN0YS1XVTNDR240QyJdfSwicHVycG9zZXMiOnsiZW5hYmxlZCI6WyJhbmFseXRpY3MtSHBCSnJySzciLCJnZW9sb2NhdGlvbl9kYXRhIl19LCJ2ZXJzaW9uIjoyLCJhYyI6IkFGbUFDQUZrLkFBQUEifQ=="
+          }
+        ],
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPgrvQAPgrvQAAHABBENCkCgAAAAAAAAAB6YAAAAAAEBoAMAAQSIJQAYAAgkQUgAwABBIghABgACCRA6ADAAEEiAkAGAAIJEDIAMAAQSIFQAYAAgkQAA.YAAAAAAAAAAA"
+          }
+        ]
+      },
+      "id": "bb9410bf-0965-418c-9375-6c6ae278fa31"
+    },
+    {
+      "click": {
+        "optIn": "button.fc-cta-consent",
+        "presence": "div.fc-footer-buttons"
+      },
+      "domain": "modrykonik.sk",
+      "cookies": {
+        "optIn": [],
+        "optOut": [
+          {
+            "name": "FCCDCF",
+            "value": "%5Bnull%2Cnull%2Cnull%2C%5B%22CPgrvQAPgrvQAEsABCSKCkCgAAAAAAAAACRQAAAOhQD2F2K2kKEkfjSUWYAQBCujIEIhUAAAAECBIAAAAUgQAgFIIAgAAlACAAAAABAQAQCAgAQABAAAgACgAAAAAAAAAAAAAAQQAABAAIAAAAAAAAAAQAAIAAQAAAAAAABEhCAAQSAEAAAAAAAAAAAAAAAAAAABAAA.YAAAAAAAAAA%22%2C%221~%22%2C%229EBAD907-6709-4964-8B38-C2711989FD29%22%5D%2Cnull%2Cnull%2C%5B%5D%5D"
+          }
+        ]
+      },
+      "id": "97909ba0-2fbd-410e-b2b9-3e165930ac61"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "presence": "div#buttons"
+      },
+      "domain": "eltiempo.es",
+      "cookies": {
+        "optIn": [],
+        "optOut": [
+          {
+            "name": "et_consent",
+            "value": "false"
+          }
+        ]
+      },
+      "id": "48f1ebe1-659a-4ded-9a87-28ab66616a70"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "presence": "div#buttons"
+      },
+      "domain": "di.se",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "_gat_UA-11873885-13",
+            "value": "1"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPgrvQAPgrvQAAHABBENCkCgAAAAAAAAAAAAAAAAAAAA.YAAAAAAAAAAA"
+          }
+        ]
+      },
+      "id": "5242b036-3490-4922-8a82-dc2be0878a4e"
+    },
+    {
+      "click": {
+        "optIn": "button#onetrust-accept-btn-handler",
+        "presence": "div#onetrust-consent-sdk"
+      },
+      "domain": "sbb.ch",
+      "cookies": {
+        "optOut": [
+          {
+            "name": "OTAdditionalConsentString",
+            "value": "1~"
+          }
+        ]
+      },
+      "id": "21526202-012c-4e5f-a7ec-277686d867bb"
+    },
+    {
+      "click": {
+        "optIn": "button#L2AGLb",
+        "optOut": "button#W0wltc",
+        "presence": "div.spoKVd"
+      },
+      "domain": "google.com.br",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "CONSENT",
+            "value": "PENDING"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "SOCS",
+            "value": "CAESHAgBEhJnd3NfMjAyMjEwMDUtMF9SQzMaAnJvIAEaBgiA5JKaBg"
+          }
+        ]
+      },
+      "id": "d94083c4-089e-4da4-8649-a1744fa2f8dd"
+    },
+    {
+      "click": {
+        "optIn": "button#button_i_accept",
+        "presence": "div#consent-info"
+      },
+      "domain": "alo.bg",
+      "cookies": {
+        "optOut": [
+          {
+            "name": "cookiesconsent",
+            "value": "{\"personalad\":true,\"lastvisited\":true}"
+          }
+        ]
+      },
+      "id": "9dcffb37-fccc-4c6f-9127-e9d2b0db7521"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "presence": "div#buttons"
+      },
+      "domain": "story.hr",
+      "cookies": {
+        "optIn": [],
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPgrvQAPgrvQAAHABBENCkCgAAAAAAAAAAAAAAAAAAAA.YAAAAAAAAAAA"
+          }
+        ]
+      },
+      "id": "735b925d-388b-4df5-b66e-2907674cd126"
+    },
+    {
+      "click": {
+        "optIn": "button.fc-cta-consent",
+        "presence": "div.fc-footer-buttons"
+      },
+      "domain": "borsonline.hu",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "FCNEC",
+            "value": "%5B%5B%22AKsRol87glA3rE51czKXQKdf0h9rbPT6f6Ctv5K6Ly3uAPIiyCzG5ShYOj9VysWIvTYhEVgeP0w6h-BRczbvzoq2udJFkGQhxjkFDhtUBITXuzgG0YH1LbU5ktUMjTxUK28S_Hj1S3ZmOWj3eVcRUj8NoGJZtsurBg%3D%3D%22%5D%2Cnull%2C%5B%5D%5D"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "FCCDCF",
+            "value": "%5Bnull%2Cnull%2Cnull%2C%5B%22CPgrvQAPgrvQAEsABCHUCkCgAAAAAAAAAA6gAAAOhQD2F2K2kKEkfjSUWYAQBCujIEIhUAAAAEKBIAAAAUgQAgFIIAgABlACEAAAABAQAQCAgAQABAAAoICgAAAAAAAAAAAAAAQQAABAAIAAAAAAAAEAQAAIAAQgAAAAAABEhCAAQQAEAAAAAAAAAAAAAAAAAAABAAA.YAAAAAAAAAA%22%2C%221~%22%2C%22BE54AC19-BDB4-438E-8831-5753F1812A3D%22%5D%2Cnull%2Cnull%2C%5B%5D%5D"
+          }
+        ]
+      },
+      "id": "a1d99e05-e32c-4cf1-931c-25c8baf538ae"
+    },
+    {
+      "click": {
+        "optIn": "button.sp_choice_type_11",
+        "optOut": "button.sp_choice_type_13",
+        "presence": "div#notice"
+      },
+      "domain": "sky.it",
+      "cookies": {},
+      "id": "0d977cde-86df-4d34-8395-737110022ebb"
+    },
+    {
+      "click": {
+        "optIn": "button.sfc-button--primary-white",
+        "presence": "div.sfc-col-lg-3"
+      },
+      "domain": "rabobank.nl",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "_fbp",
+            "value": "fb.1.1665489826730.1028115920"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "RABO_PSL",
+            "value": "1"
+          }
+        ]
+      },
+      "id": "fe8a3adb-ce3c-4dd6-83db-772e71674da3"
+    },
+    {
+      "click": {
+        "optIn": "button.cmp-intro_acceptAll",
+        "presence": "div.cmp-intro_options"
+      },
+      "domain": "fakt.pl",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "_gat_UA-4033697-1",
+            "value": "1"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "adpconsent",
+            "value": "CPgtaEHPgtaGrEYACAENCbCgAIAAAH_AAB5YI8QAAR4AJMNW4gC7EscCbQMIoUQIwrCQqgUAEFAMLRBYAODgp2VgE-sIWACAUARgRAhxBRgwCAAQCAJCIAJAiwQCIAiAQAAgARAIQAETAILACwMAgABANCxQCgAECQgyICI5TAgIgSCglsrEEoK9DTCAOssAKDRGxUACJAABSAgJCwcAwRICXiyQJMUb5ACMEKAUSoAA.cAAAAbgAAIAA"
+          }
+        ]
+      },
+      "id": "f192b6a8-1d6d-4448-b971-2794d0834356"
+    },
+    {
+      "click": {
+        "optIn": "button#onetrust-accept-btn-handler",
+        "presence": "div#onetrust-consent-sdk"
+      },
+      "domain": "stiripesurse.ro",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "cto_bundle",
+            "value": "Jo6UWl9SNGtwTHZta1hqU0VNOVVGQ3RoMURSaHdDZGo3SFpQZ0RPV1FDTmdCa3pDbXZnMzdJbFQ2VmZMWVF5UHI4OFFXOHluSzhlcHFzWkJtdTh0OTlLWjBhZzdYTjFqWk1zenpEMHZPY291QXVQYW9HaSUyQllURlJ1aXQ3WmklMkJ2NkFaRnc"
+          }
+        ]
+      },
+      "id": "3a0edb0a-5fe3-45b2-8de2-761369c287cd"
+    },
+    {
+      "click": {
+        "optIn": "a.cmptxt_btn_yes",
+        "presence": "div.cmpboxbtns"
+      },
+      "domain": "informer.rs",
+      "cookies": {
+        "optOut": [
+          {
+            "name": "__cmpcc",
+            "value": "1"
+          }
+        ]
+      },
+      "id": "27572d79-fc44-49f0-b271-bd44e76f3a3f"
+    },
+    {
+      "click": {
+        "optIn": "button#onetrust-accept-btn-handler",
+        "presence": "div#onetrust-consent-sdk"
+      },
+      "domain": "atg.se",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "_fbp",
+            "value": "fb.1.1665560121992.736145080"
+          },
+          {
+            "name": "_ga",
+            "value": "GA1.2.1253531272.1665560121"
+          },
+          {
+            "name": "da_lid",
+            "value": "468EE9699A7AEA12845BBB99F59F2C96DC|0|0|0"
+          },
+          {
+            "name": "_gcl_au",
+            "value": "1.1.352529906.1665560121"
+          }
+        ],
+        "optOut": []
+      },
+      "id": "8489dcdb-17cc-4aef-918a-1fac06494354"
+    },
+    {
+      "click": {
+        "optIn": "button.eu-cookie-compliance-default-button",
+        "presence": "div#popup-buttons"
+      },
+      "domain": "eluniversal.com.mx",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "cookie-agreed",
+            "value": "2"
+          },
+          {
+            "name": "cookie-agreed-version",
+            "value": "1.0.0"
+          }
+        ],
+        "optOut": []
+      },
+      "id": "34e9d8ee-5e8d-462c-ab39-d25260124cf6"
+    },
+    {
+      "click": {
+        "optIn": "button.accept",
+        "optOut": "button.close",
+        "presence": "div#notice"
+      },
+      "domain": "wetteronline.de",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "cto_bundle",
+            "value": "mK-mGF9LaSUyRmVJNVM0cVV4ekhWdnp1Z3ZnWW9hSVZNb2wxSHJURzczazlkamlPU25Pb0c3aXg5UG5BSklvSUVoMkU0VlduWnN2Yjk5U2xkJTJCMGNwaldzME9NZ3Foc0xGYjAyJTJCRTFzRlNuZm5HM29xbVFWVkxLVXVsWmZJek5zQWlPUlBEeA"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPgvCMAPgvCMAAGABBDECkCgAAAAAELAACJwAAALzgBALQAXmAAA.YAAAAAAAAAAA"
+          },
+          {
+            "name": "_pbjs_userid_consent_data",
+            "value": "2614023073969325"
+          }
+        ]
+      },
+      "id": "8bf0ff7b-38bf-47e3-8551-b0f586dd8b67"
+    },
+    {
+      "click": {
+        "optIn": "a#kmcc-accept-all-cookies",
+        "presence": "div.kmcc-cookie-bar__footer__preferences__second"
+      },
+      "domain": "meteo.be",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "legal_cookie",
+            "value": "%7B%22cookies%22%3A%7B%22functional_cookie%22%3A%22true%22%2C%22analyzing_cookie%22%3A%22true%22%7D%2C%22cookie_log_id%22%3A%2225634502%22%2C%22cookie_version%22%3A20200608%7D"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "legal_cookie",
+            "value": "%7B%22cookies%22%3A%7B%22functional_cookie%22%3A%22true%22%2C%22analyzing_cookie%22%3A%22false%22%2C%22marketing_cookie%22%3A%22false%22%7D%2C%22cookie_log_id%22%3A%2225634476%22%2C%22cookie_version%22%3A20200608%7D"
+          }
+        ]
+      },
+      "id": "67e420b4-05e6-4c01-a999-0d48dba85362"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "presence": "div#buttons"
+      },
+      "domain": "in-pocasi.cz",
+      "cookies": {},
+      "id": "d1629633-085e-4af7-8e69-b69eda820792"
+    },
+    {
+      "click": {
+        "optIn": "a.wscrOk",
+        "presence": "div.wscrBannerContent"
+      },
+      "domain": "nordea.com",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "wscrCookieConsentShared",
+            "value": "1=true&2=true&3=true&4=true&5=true&visitor=03bfbe89-44d7-4da3-ad3f-a1a8a8285257&version=20221005-001"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "wscrCookieConsentShared",
+            "value": "1=true&2=false&3=false&4=false&5=false&visitor=5698152c-e2fd-4076-b411-f8baed432e40&version=20221005-001"
+          }
+        ]
+      },
+      "id": "fe09c786-b60e-455e-abd6-212c8878f06a"
+    },
+    {
+      "click": {
+        "optIn": "button.css-k8o10q",
+        "presence": "div.qc-cmp2-summary-buttons"
+      },
+      "domain": "athensmagazine.gr",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "cto_bundle",
+            "value": "dmF2h19lNUpidloybGpaRGpGSTJtb1dKbiUyQnAlMkJZa0Z2UzZJUURoNDNHc1BreUM5UnJScHVMSHdBOElGTGMwcGd1QmxDa09nSThkNUJPdmU2cFZwVXQ2bUl0R0k3WmZKU29idWo0ek9KSDklMkZyU2VFM0hxYjglMkIxelRseVdQRnklMkJzMFpYelM"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "addtl_consent",
+            "value": "1~"
+          },
+          {
+            "name": "euconsent-v2",
+            "value": "CPgvCMAPgvCMAAKAsAELCkCgAAAAAH_AAAyIAAASIAJMNW4gC7MscGbQMIoEQIwrCQqgUAEFAMLRAYAODgp2VgE-sIEACAUARgRAhwBRgQCAAASAJCIAJAiwQAAAiAQAAgARCIQAMDAILACwMAgABANAxRCgAECQgyICIpTAgKgSCA1sqEEoLpDTCAOssAKCRGxUACIJARWAAICwcAwRICViwQJMUb5ACMEKAUSoVqIAAAAA.YAAAAAAAAAAA"
+          }
+        ]
+      },
+      "id": "c0e69dcc-9602-4d7a-89b8-a4a06f0432ca"
+    },
+    {
+      "click": {
+        "optIn": "button.sp_choice_type_11",
+        "presence": "div#notice"
+      },
+      "domain": "thesun.ie",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "cto_bundle",
+            "value": "W4QVoV9GekNsVHN1S1RkZVFiM1FVZ0MzJTJCd0tYdnN0a3Z2M3dLYlZaS0tiRFVVckpFcSUyQk9HUWo0OXlWVGRRcllwYnBURGpkaUd3YlBCS0o5aHBnMWkxSWhkUjMycTQyMEVFWFg4ZmIybWJUJTJCMnNHTyUyRjB5b1VvZlQxblJOWXY5emYyV0xv"
+          },
+          {
+            "name": "_pbjs_userid_consent_data",
+            "value": "4539734045513866"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "_pbjs_userid_consent_data",
+            "value": "1255130838881277"
+          }
+        ]
+      },
+      "id": "dda8ca87-e3cf-4abe-8d09-7e4591846fff"
+    },
+    {
+      "click": {
+        "optIn": "button#onetrust-accept-btn-handler",
+        "presence": "div#onetrust-consent-sdk"
+      },
+      "domain": "voetbalzone.nl",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "cto_bundle",
+            "value": "1LPmpF9vZDF6eUUzSW4lMkZ5UFppaklSNEtMJTJGTUNyR1R6JTJCbWVaTVh0Nkg5VDZXdVRLJTJCS1VuNWFIM2glMkJIMnczcmRYU1JjNENYSUJoNCUyQmU0dGlJd29PeDlQc1I2SEVPazRvekNBYmd1NFFxVVFldWI2eDNlZ2FMSVhubmRNeU1XZlRiT3htRg"
+          },
+          {
+            "name": "eupubconsent-v2",
+            "value": "CPgwUhcPgwUn5AcABBENCkCsAP_AAH_AAChQJDtf_X__b2_r-_5_f_t0eY1P9_7__-0zjhfdl-8N3f_X_L8X52M7vF36tq4KuR4ku3LBIUdlHOHcTUmw6okVryPsbk2cr7NKJ7PEmnMbOydYGH9_n1_z-ZKY7___f_7z_v-v___3____7-3f3__5___-__e_V__9zfn9_____9vP___9v-_9__________3_7994JEAEmGrcQBdmWODNtGEUCIEYVhIdQKACigGFogMIHVwU7K4CfWECABAKAJwIgQ4AowYBAAAJAEhEQEgR4IBAARAIAAQAKhEIAGNgEFgBYGAQACgGhYoxQBCBIQZEBEUpgQFSJBQb2VCCUH-hphCHWWAFBo_4qEBGsgYrAiEhYOQ4IkBLxZIHmKN8gBGCFAKJUK1EAAAA.f_gAD_gAAAAA"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "eupubconsent-v2",
+            "value": "CPgwSjtPgwSntAcABBENCkCgAAAAAH_AAChQJDtf_X__b2_r-_5_f_t0eY1P9_7__-0zjhfdl-8N3f_X_L8X52M7vF36tq4KuR4ku3LBIUdlHOHcTUmw6okVryPsbk2cr7NKJ7PEmnMbOydYGH9_n1_z-ZKY7___f_7z_v-v___3____7-3f3__5___-__e_V__9zfn9_____9vP___9v-_9__________3_7994JEAEmGrcQBdmWODNtGEUCIEYVhIdQKACigGFogMIHVwU7K4CfWECABAKAJwIgQ4AowYBAAAJAEhEQEgR4IBAARAIAAQAKhEIAGNgEFgBYGAQACgGhYoxQBCBIQZEBEUpgQFSJBQb2VCCUH-hphCHWWAFBo_4qEBGsgYrAiEhYOQ4IkBLxZIHmKN8gBGCFAKJUK1EAAAA.YAAAD_gAAAAA"
+          }
+        ]
+      },
+      "id": "a6192568-13e7-4a26-b492-cafe2df9346a"
+    },
+    {
+      "click": {
+        "optIn": "button.cookie-banner-lgpd_accept-button",
+        "presence": "div#cookie-banner-lgpd"
+      },
+      "domain": "globo.com",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "cookie-banner-accepted-version",
+            "value": "1.3.2.1"
+          }
+        ],
+        "optOut": []
+      },
+      "id": "90b8eda3-d964-4301-94fc-646e92d33d56"
+    },
+    {
+      "click": {
+        "optIn": "button#onetrust-accept-btn-handler",
+        "optOut": "button#onetrust-reject-all-handler",
+        "presence": "div#onetrust-consent-sdk"
+      },
+      "domain": "stirileprotv.ro",
+      "cookies": {},
+      "id": "c78b44a7-1c7f-4779-8def-88bded30e86e"
+    },
+    {
+      "click": {
+        "optIn": "button.kitt-cookie-warning__close",
+        "presence": "div.kitt-cookie-warning__content"
+      },
+      "domain": "sberbank.ru",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "sbrf.pers_notice",
+            "value": "1"
+          }
+        ],
+        "optOut": []
+      },
+      "id": "40746884-0f10-4e12-ab0d-2a4410b1e0f9"
+    },
+    {
+      "click": {
+        "optIn": "a#cn-accept-cookie",
+        "presence": "div#cookie-notice"
+      },
+      "domain": "danas.rs",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "cookie_notice_accepted",
+            "value": "true"
+          }
+        ]
+      },
+      "id": "d6ee6a87-66ad-4c35-88ac-966d4fff81f7"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "presence": "div#buttons"
+      },
+      "domain": "hola.com",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "cto_bundle",
+            "value": "3zBPF194WFBCdFphOTVQQW9LN2RPeFB3OUFyN0lnMHIwdWUydVBsRFBKUWRRdVhEY0ZFMk8zRkJPNiUyRloyTzJFVHpNbk5Gb1BKNmlXUmhFTzU4c1FZJTJCWjV3cFhmRmlTd3YyU2U2bTZwWkc3Z29VMktzdDBqNnNVWCUyQmRPdDA3eEQ1M1QlMkJR"
+          },
+          {
+            "name": "vendorconsents",
+            "value": "Wzc3XQ=="
+          }
+        ],
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPgvCMAPgvCMAAHABBENCkCgAAAAAAAAAAAAAAAAAAAA.YAAAAAAAAAAA"
+          },
+          {
+            "name": "vendorconsents",
+            "value": "W10="
+          }
+        ]
+      },
+      "id": "b7c989d5-34e7-488c-a313-d9805d822b01"
+    },
+    {
+      "click": {
+        "optIn": "button.sp_choice_type_11",
+        "presence": "div#notice"
+      },
+      "domain": "thesun.co.uk",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "cto_bundle",
+            "value": "3-WNyF9VTEZuRkc4dUZPa0E2VEFxTlNjUDdZclg1WXlGZEJGNm1vSmlhaVFIQjAlMkJWdHdHM3VsT2pOTnVzaWNDam1HbjFveWExQmVwbzljVWJ6OXZ3aGRjJTJCS0V2TkNTa0x5cVowTkRvOFZSck1iRDVnbDZpSVgzNnAlMkJ4akwydjRzWSUyQkc4"
+          },
+          {
+            "name": "_pbjs_userid_consent_data",
+            "value": "4539734045513866"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "nukt_sp_consent_v2",
+            "value": "1255130838881277"
+          },
+          {
+            "name": "_pbjs_userid_consent_data",
+            "value": "1255130838881277"
+          }
+        ]
+      },
+      "id": "e27c2360-e14c-40f9-aae6-96641be5a719"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "presence": "div#buttons"
+      },
+      "domain": "lesoir.be",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "_fbp",
+            "value": "fb.1.1665575112238.1466032619"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPgvCMAPgvCMAAHABBENCkCgAAAAAAAAAAAAAAAAAAEkoAMAAQSIDQAYAAgkQKgAwABBIgpABgACCRA6ADAAEEiCEAGAAIJEBIAMAAQSIEQAYAAgkQMgAwABBIgA.YAAAAAAAAAAA"
+          }
+        ]
+      },
+      "id": "59ab77c6-e347-4988-a643-9e4aa60e3ccc"
+    },
+    {
+      "click": {
+        "optIn": "button.fc-cta-consent",
+        "presence": "div.fc-footer-buttons-container"
+      },
+      "domain": "rtl.hr",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "FCNEC",
+            "value": "%5B%5B%22AKsRol8dX3obOP7yDUss1XiFtDeudrjxUqYpP-rhMQ4efd-tCsA-zwr0QEIFFzJqFPlqONzKSl_dmYl2Hz5ExOkq0Ddboia9nRAZW9HKJKqbq84FAUkt7fH8n_ttCQMi3xDh6FUQi3u0z8HbAboNtASE5TTkNhan1w%3D%3D%22%5D%2Cnull%2C%5B%5D%5D"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "FCCDCF",
+            "value": "%5Bnull%2Cnull%2Cnull%2C%5B%22CPgvCMAPgvCMAEsABCHRCkCgAAAAAAAAAA6IAAARTY7-N262v7O8fnfUebo0Rq-r-Uv1cBmHCOLRo4BOX8t-VgH-sJ2ALt0aVgRMjxJZqQCQgISAJOICpNi0RIqWiGQQAkxRAaQQ2DJILYy8sCgIJIfFxKCsAUzy9zcSM7zklvx3Tf9v7lut7rrfiZet8HLoXGz9xbaNtbe8AIywcE4ZqSVrxaZ-d__pmcAA.YAAAAAAAAAA%22%2C%221~%22%2C%228B9BF72F-C252-4FA2-A91E-8632E50EC476%22%5D%2Cnull%2Cnull%2C%5B%5D%5D"
+          }
+        ]
+      },
+      "id": "1d9f6559-cbc8-4cdb-b5f5-ca24844621d3"
+    },
+    {
+      "click": {
+        "optIn": "a#CybotCookiebotDialogBodyLevelButtonLevelOptinAllowAll",
+        "optOut": "a#CybotCookiebotDialogBodyLevelButtonLevelOptinDeclineAll",
+        "presence": "div#CybotCookiebotDialogBodyLevelButtonLevelOptinAllowallSelectionWrapper"
+      },
+      "domain": "e-boks.com",
+      "cookies": {},
+      "id": "a1bb84f0-e248-4576-8cd5-722622120a7d"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "optOut": "button#didomi-notice-disagree-button",
+        "presence": "div#buttons"
+      },
+      "domain": "free.fr",
+      "cookies": {},
+      "id": "d1359663-b2df-4ce5-849f-67c679e08383"
+    },
+    {
+      "click": {
+        "optIn": "button.css-1kpvtti",
+        "presence": "div.qc-cmp2-summary-buttons"
+      },
+      "domain": "voetbalprimeur.nl",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "cookie_consent",
+            "value": "true"
+          },
+          {
+            "name": "cto_bundle",
+            "value": "kjdgil90b1NYZk11R2FLSXNXTVpjSngzd3VTQUNpY1dzVWxvMGMzZkYlMkJCSENrblpmT2hkdlNLUEF4aGNJeFBrTiUyRmdXRm9aa2lSTVo4elFLbzJGZG56dkpocGN0T2dVV2hYMCUyQllGSkJWYnR1cjNEdnhDS2ZlVVcyMUR0U1BHU2V2SHRIZQ"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPgvCMAPgvCMAAKAsBNLCkCgAAAAAH_AABpYAAASIAJMNW4gC7MscGbQMIoEQIwrCQqgUAEFAMLRAYAODgp2VgE-sIEACAUARgRAhwBRgQCAAASAJCIAJAiwQAAAiAQAAgARCIQAMDAILACwMAgABANAxRCgAECQgyICIpTAgKgSCAlsqEEoLpDTCAOssAKCRGxUACIJARWAAICwcAwRICViwQJMUb5ACMEKAUSoVqIAAAAA.YAAAAAAAAAAA"
+          },
+          {
+            "name": "addtl_consent",
+            "value": "1~"
+          }
+        ]
+      },
+      "id": "17c60799-e59b-475f-8007-fec046609121"
+    },
+    {
+      "click": {
+        "optIn": "button.consent-accept",
+        "presence": "div#consent-accept"
+      },
+      "domain": "dnb.no",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "s_cc",
+            "value": "true"
+          }
+        ]
+      },
+      "id": "0b8969b6-d5a1-4358-967b-524a2c998233"
+    },
+    {
+      "click": {
+        "optIn": "button#onetrust-accept-btn-handler",
+        "presence": "div#onetrust-consent-sdk"
+      },
+      "domain": "ziare.com",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "cto_bidid",
+            "value": "ImBbul9LeWtNb1loMXphWXR6aVdKZklweElQRVlkdzZ0cUcxa01WaVNkUjFoJTJCJTJGbnRKcXdVQXY0UzNtemFscXBTYU00MmVxWVhaSk9zZVVKaFk1UmpIaEJiaFElM0QlM0Q"
+          },
+          {
+            "name": "cto_bundle",
+            "value": "Y98NpF9sa2pVJTJGJTJCamN6NFlkV3RVdTg0Y3hNVnEydnFQJTJCR3UzOFJqeWRBa0NnUiUyQmNFVHJKSzFRdGh2dHJnQ2RQMnNNVDZnZ3hVS3ZVcndxR3dFb1JXVVNOdzFOb3RYb0R3eVpyWVZFSjJNdHVscGxuUEVLVmluczZUa2czc2tHZWhFUFJz"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "_pbjs_userid_consent_data",
+            "value": "5926349545446984"
+          }
+        ]
+      },
+      "id": "cb280b52-b9c2-448d-a0f5-27ec158fdd51"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "presence": "div#buttons"
+      },
+      "domain": "eldiario.es",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "cto_bundle",
+            "value": "VurNJF9SJTJCVmU3UXJ0OHFJT0REdm1ORHJMZmxxV0tNOFphejJCU0VEV0ZTanFHdTFwbFdNbThEVkJnSjI0dmdxa2RaQ3klMkZXT1JmJTJGek8wRnB2eTBZdmdZMkt0OVFZOHQ0TDMzc095WWtsT1RWZUV1bGslMkZJZ1FyVjR2THhFSyUyQkQ5NmFUS08"
+          },
+          {
+            "name": "euconsent-v2",
+            "value": "CPgvCMAPgvCMAAHABBENCkCsAP_AAH_AAAiQJDtf_X__b2_r-_5_f_t0eY1P9_7__-0zjhfdl-8N3f_X_L8X52M7vF36tq4KuR4ku3LBIUdlHOHcTUmw6okVryPsbk2cr7NKJ7PEmnMbOydYGH9_n1_z-ZKY7___f_7z_v-v___3____7-3f3__5___-__e_V__9zfn9_____9vP___9v-_9__________3_7994JCAEmGrcQBdiWOBNtGEUCIEYVhIdQKACigGFogMIHVwU7K4CfWECABAKAIwIgQ4AowYBAAABAEhEQEgR4IBAARAIAAQAKhEIACNgEFABYGAQACgGhYoxQBCBIQZEBEUpgQESJBQT2VCCUH-hphCHWWAFBo_4qEBEoAQrAiEhYOQ4IkBLxZIFmKN8gBGCFAKJUK1AAAAA.f_gAD_gAAAAA"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPgvCMAPgvCMAAHABBENCkCgAAAAAH_AAAiQAAASEAJMNW4gC7EscCbaMIoEQIwrCQ6gUAFFAMLRAYQOrgp2VwE-sIEACAUARgRAhwBRgwCAAACAJCIgJAjwQCAAiAQAAgAVCIQAEbAIKACwMAgAFANCxRigCECQgyICIpTAgIkSCgnsqEEoP9DTCEOssAKDR_xUICJQAhWBEJCwchwRICXiyQLMUb5ACMEKAUSoVqAA.YAAAD_gAAAAA"
+          }
+        ]
+      },
+      "id": "dad83ae7-5d03-4589-83af-83458f8c1518"
+    },
+    {
+      "click": {
+        "optIn": "button#onetrust-accept-btn-handler",
+        "optOut": "button#onetrust-reject-all-handler",
+        "presence": "div#onetrust-consent-sdk"
+      },
+      "domain": "1177.se",
+      "cookies": {},
+      "id": "4c6972fe-024e-4d44-94b6-01fa216f511c"
+    },
+    {
+      "click": {
+        "optIn": "button.js-cookies-hide",
+        "presence": "div.cookie-label__btn-set"
+      },
+      "domain": "nv.ua",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "cookieApprove",
+            "value": "true"
+          }
+        ]
+      },
+      "id": "e8aa7447-2f27-4b65-bbdb-dcecc30c6c1f"
+    },
+    {
+      "click": {
+        "optIn": "button.css-1x99van",
+        "presence": "div.qc-cmp2-summary-buttons"
+      },
+      "domain": "express.co.uk",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPgzfGvPgzfGvAKAmAENCkCsAP_AAH_AAAwIJDtd_H__bW9r-f5_aft0eY1P9_r37uQzDhfNk-8F3L_W_LwX52E7NF36tq4KmR4ku1LBIUNlHMHUDUmwaokVryHsak2cpzNKJ7BEknMZOydYGF9vmxtj-QKY7_5_dzbx2D-t_9v239z3z81Xn3d53-_03LCdV5_9Dfn9fR_bc9KPt_58v8v8_____3_e__3_7994JEAEmGrcQBdmWODNoGEUCIEYVhIVQKACCgGFogMAHBwU7KwCfWECABAKAIwIgQ4AowIBAAAJAEhEAEgRYIAAARAIAAQAIhEIAGBgEFgBYGAQAAgGgYohQACBIQZEBAUpgQFQJBAa2VCCUF0hphAHWWAFBIjYqABEEgIrAAEBYOAYIkBKxYIEmKN8gBGCFAKJUK1EAAAA.f_gAAAAAAAAA"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPgzdxQPgzdxQAKAmBENCkCgAAAAAH_AAAwIAAASIAJMNW4gC7MscGbQMIoEQIwrCQqgUAEFAMLRAYAODgp2VgE-sIEACAUARgRAhwBRgQCAAASAJCIAJAiwQAAAiAQAAgARCIQAMDAILACwMAgABANAxRCgAECQgyICApTAgKgSCA1sqEEoLpDTCAOssAKCRGxUACIJARWAAICwcAwRICViwQJMUb5ACMEKAUSoVqIAAAAA.YAAAAAAAAAAA"
+          },
+          {
+            "name": "addtl_consent",
+            "value": "1~"
+          }
+        ]
+      },
+      "id": "edaa2c50-1fbc-4287-8d15-68af2b5dc1bf"
+    },
+    {
+      "click": {
+        "optIn": "button#truste-consent-button",
+        "optOut": "div#truste-consent-required",
+        "presence": "div.truste-consent-content"
+      },
+      "domain": "samsung.com",
+      "cookies": {},
+      "id": "943a1f39-57c2-430e-b91d-81a659d9b036"
+    },
+    {
+      "click": {
+        "optIn": "button.sp_choice_type_11",
+        "presence": "div#notice"
+      },
+      "domain": "oikotie.fi",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPgyVIAPgyVIAAGABCENCkCgAP_AAEPAACJwF5wIQAEAASAAqABcADwAIAAZAA0ACJAEwATQAngBUAC2AF8AP0AgACCAEIANEAhABEQCJgEWAI6ASIAwIBigDTAIFARqAnABVgC2QF5gXnAZAAQABIACoAFwAQAAyABoAESAJgAmgBPAD8AIQAZoA0QCEAERAIsASIAwIBigEyAKsAWyAu8BeYBgyAEAEwBeYSAGAB4APwBigoAMAaIBCAFshAAQAWwCOjoAIBHR4AIAJoC2SEAMAJgBigFWEAAIAzSUAUABAARAAmAGKAXmSAAgDNKQDgAKgAgABkADQAIgATAAngB-AGiARYAjoBigFWALzFQAgAmALzAA.YAAAAAAAAAAA"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPgyVIAPgyVIAAGABCFICkCgAAAAAAAAACJwAAAAAAAA.YAAAAAAAAAAA"
+          }
+        ]
+      },
+      "id": "a36eac81-61fd-4d28-92d9-ef11da855a21"
+    },
+    {
+      "click": {
+        "optIn": "button.css-1lgi3ta",
+        "presence": "div.qc-cmp2-summary-buttons"
+      },
+      "domain": "pronews.gr",
+      "cookies": {
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPgyVIAPgyVIAAKAsAELCkCgAAAAAH_AAAyIAAASIAJMNW4gC7MscGbQMIoEQIwrCQqgUAEFAMLRAYAODgp2VgE-sIEACAUARgRAhwBRgQCAAASAJCIAJAiwQAAAiAQAAgARCIQAMDAILACwMAgABANAxRCgAECQgyICIpTAgKgSCA1sqEEoLpDTCAOssAKCRGxUACIJARWAAICwcAwRICViwQJMUb5ACMEKAUSoVqIAAAAA.YAAAAAAAAAAA"
+          },
+          {
+            "name": "addtl_consent",
+            "value": "1~"
+          }
+        ]
+      },
+      "id": "9e16f526-4d46-4c2e-a3ed-d3b43d67b4fb"
+    },
+    {
+      "click": {
+        "optIn": "button.fc-cta-consent",
+        "presence": "div.fc-footer-buttons"
+      },
+      "domain": "nemzetisport.hu",
+      "cookies": {
+        "optOut": [
+          {
+            "name": "cto_bundle",
+            "value": "DkANH185MkxWWGtYemZxZzZibU9McFE1NE1GNGVDeXN6aWFyJTJCWVJLaXNtTjgyTXlpa0I0JTJGT1lXazBRODJhMTJsdTQ3THBDdHRaRWkwZFZUNlFkNGFNa2NTaTlzS3E1RmF1djBTcGN5SFozTTBPcFglMkZMNDVHJTJCek94JTJCQ1dYNjklMkZMUFlmdQ"
+          },
+          {
+            "name": "euconsent-v2",
+            "value": "CPgyVIAPgyVIAAKAsAELCkCsAP_AAH_AAAyIJDtd_H__bW9r-f5_aft0eY1P9_r37uQzDhfNk-8F3L_W_LwX52E7NF36tq4KmR4ku1LBIUNlHMHUDUmwaokVryHsak2cpzNKJ7BEknMZOydYGF9vmxtj-QKY7_5_d3bx2D-t_9v239z3z81Xn3d53-_03LCdV5_9Dfn9fR_bc9KPt_58v8v8_____3_e__3_7994JEAEmGrcQBdmWODNoGEUCIEYVhIVQKACCgGFogMAHBwU7KwCfWECABAKAIwIgQ4AowIBAAAJAEhEAEgRYIAAARAIAAQAIhEIAGBgEFgBYGAQAAgGgYohQACBIQZEBEUpgQFQJBAa2VCCUF0hphAHWWAFBIjYqABEEgIrAAEBYOAYIkBKxYIEmKN8gBGCFAKJUK1EAAAA.f_gAAAAAAAAA"
+          }
+        ]
+      },
+      "id": "da1104e6-0ce0-4956-bd53-fd13c5c2c90b"
+    },
+    {
+      "click": {
+        "optIn": "button#gdpr-banner-accept",
+        "optOut": "button#gdpr-banner-decline",
+        "presence": "div.gdpr-banner-actions"
+      },
+      "domain": "ebay.it",
+      "cookies": {},
+      "id": "0bee4c78-484e-4f21-8585-f089bc7618f5"
+    },
+    {
+      "click": {
+        "optIn": "button.button--primary",
+        "presence": "div.modal__body"
+      },
+      "domain": "swisscom.ch",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "CONSENTMGR",
+            "value": "c1:1%7Cc6:1%7Cc7:1%7Cc15:1%7Cconsent:true%7Cts:1665653237583"
+          }
+        ],
+        "optOut": []
+      },
+      "id": "3c03e0ec-aa84-48a1-83ca-0bf07d24e20e"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "presence": "div#buttons"
+      },
+      "domain": "vesti.bg",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPgyVIAPgyVIAAHABBENCkCsAP_AAE7AAAIwGMwFgAFAANAAgABUADoAIAAVAAyABoAEUALYAYQBCAFIATSAo8BUgC4QFygLpAXmAxkC84A4AFQAQAAyABoAEUAQgC8wAg0AGAAIJECIAMAAQSIA.f_gACdgAAAAA"
+          },
+          {
+            "name": "cto_bundle",
+            "value": "H0nCJV9ZRDhEYXplRUh1ekwlMkJBTUVWMUpNTWwxWk9DR3p0VkJGUUtFWUdBOTFPSDglMkZmSzBJMXVKTjRzUDhkWTNFUGdUVmxDQWZkcXRIaE43UUgzTGYwYkFhQlcwMTIweEoxVjd5QjBVUVFDckNnUzJ6bUY5ZzJwdWklMkI3clhjZ0hyS1ByNA"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "_pbjs_userid_consent_data",
+            "value": "3363976719618801"
+          },
+          {
+            "name": "euconsent-v2",
+            "value": "CPgyVIAPgyVIAAHABBENCkCgAAAAAAAAAAIwAAAAAABBoAMAAQSIEQAYAAgkQAAA.YAAAAAAAAAAA"
+          }
+        ]
+      },
+      "id": "710bc9ab-7a81-4017-a7e8-d430da5c9d83"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "presence": "div#buttons"
+      },
+      "domain": "gloria.hr",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPgyVIAPgyVIAAHABBENCkCsAP_AAH_AAAAAJDtf_X__b2_r-_5_f_t0eY1P9_7__-0zjhfdl-8N3f_X_L8X52M7vF36tq4KuR4ku3LBIUdlHOHcTUmw6okVryPsbk2cr7NKJ7PEmnMbOydYGH9_n1_z-ZKY7___f_7z_v-v___3____7-3f3__5___-__e_V__9zfn9_____9vP___9v-_9__________3_7994JCAEmGrcQBdiWOBNtGEUCIEYVhIdQKACigGFogMIHVwU7K4CfWECABAKAIwIgQ4AowYBAAABAEhEQEgR4IBAARAIAAQAKhEIACNgEFABYGAQACgGhYoxQBCBIQZEBEUpgQESJBQT2VCCUH-hphCHWWAFBo_4qEBEoAQrAiEhYOQ4IkBLxZIFmKN8gBGCFAKJUK1AAAAA.f_gAD_gAAAAA"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPgyVIAPgyVIAAHABBENCkCgAAAAAAAAAAAAAAAAAAAA.YAAAAAAAAAAA"
+          }
+        ]
+      },
+      "id": "dc88edb5-a5da-4d2d-b980-7881354985e3"
+    },
+    {
+      "click": {
+        "optIn": "button#CybotCookiebotDialogBodyLevelButtonLevelOptinAllowAll",
+        "optOut": "button#CybotCookiebotDialogBodyButtonDecline",
+        "presence": "div#CybotCookiebotDialogBodyButtonsWrapper"
+      },
+      "domain": "politiken.dk",
+      "cookies": {},
+      "id": "1006f951-cd51-47cc-9527-5036cef4b85a"
+    },
+    {
+      "click": {
+        "optIn": "button#almacmp-modalConfirmBtn",
+        "presence": "div.almacmp-controls"
+      },
+      "domain": "nettiauto.com",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "gravitoData",
+            "value": "{\"TCString\":\"CPgyVIAPgyVIABUAJAFICkCsAP_AAH_AAApAHxQIwAFgAQAAqABkADwAIAAZAA0AB8AEQAI4ATwAqABbADmAH4AQUAhACFAEwANEAbIBCACIgEWAJEATsAtIBgQDFAHUAP0AmQBbIC8wHxAfFAdAAWABUADIAHgAQAAyABoAD4AIgATwA5gB-AEIAJgAaIA2QCEAERAIsASIAtIBgQDFAGfAOoAmQBeYDBAHxAEhIB4ACwAKgAZAA8ACAAGQANAAiABPADmAH4AQgA2QDFALzDQAgBsgFpEQAQBsioAQBaQF5jIAIC8x0BQABYAFQAMgAgABkADQAHwARAAngBzAD8AJgAaIA2QCLAFpAMUAdQBMgC8yEAUABYAGQC0gGKAOoSgEAALAAyAEQAbIBaQDFAHUAXmUgHgALAAqABkAEAAMgAaABEACeAHMAPwA0QBsgEWAMUAvMAAA.YAAAAAAAAMAA\",\"NonTCFVendors\":[{\"id\":1,\"name\":\"Facebook\",\"consent\":true},{\"id\":3,\"name\":\"Google\",\"consent\":true},{\"id\":4,\"name\":\"Chartbeat\",\"consent\":true},{\"id\":5,\"name\":\"Giosg\",\"consent\":true},{\"id\":6,\"name\":\"Hotjar\",\"consent\":true},{\"id\":7,\"name\":\"Qualifio\",\"consent\":true},{\"id\":8,\"name\":\"Questback\",\"consent\":true},{\"id\":9,\"name\":\"Twitter\",\"consent\":true},{\"id\":10,\"name\":\"Wordpress\",\"consent\":true},{\"id\":15,\"name\":\"Linkedin\",\"consent\":true},{\"id\":16,\"name\":\"Microsoft\",\"consent\":true},{\"id\":17,\"name\":\"OneSignal\",\"consent\":true},{\"id\":18,\"name\":\"AppCues\",\"consent\":true},{\"id\":19,\"name\":\"Vimeo\",\"consent\":true},{\"id\":21,\"name\":\"Finnchat\",\"consent\":true},{\"id\":22,\"name\":\"Lekane\",\"consent\":true},{\"id\":23,\"name\":\"Zendesk\",\"consent\":true},{\"id\":24,\"name\":\"Serviceform\",\"consent\":true},{\"id\":25,\"name\":\"Smilee\",\"consent\":true},{\"id\":26,\"name\":\"Calendly\",\"consent\":true},{\"id\":27,\"name\":\"Apple\",\"consent\":true},{\"id\":28,\"name\":\"Cavai\",\"consent\":true},{\"id\":29,\"name\":\"Selligent\",\"consent\":true}]}"
+          },
+          {
+            "name": "__nettix-vendor-consent",
+            "value": "{\"standardPurpose\":[1,2,3,4,5,6,7,8,9,10],\"vendorConsents\":{\"1\":true,\"3\":true,\"4\":true,\"5\":true,\"6\":true,\"7\":true,\"8\":true,\"9\":true,\"10\":true,\"11\":true,\"15\":true,\"16\":true,\"17\":true,\"18\":true,\"19\":true,\"21\":true,\"22\":true,\"23\":true,\"24\":true,\"25\":true,\"26\":true,\"27\":true,\"28\":true,\"29\":true,\"30\":true,\"32\":true,\"50\":true,\"52\":true,\"62\":true,\"68\":true,\"71\":true,\"79\":true,\"84\":true,\"91\":true,\"115\":true,\"126\":true,\"130\":true,\"132\":true,\"133\":true,\"152\":true,\"209\":true,\"217\":true,\"264\":true,\"273\":true,\"278\":true,\"290\":true,\"315\":true,\"361\":true,\"385\":true,\"394\":true,\"415\":false,\"468\":true,\"506\":true,\"612\":true,\"729\":true,\"755\":true,\"772\":false,\"994\":true}}"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "gravitoData",
+            "value": "{\"TCString\":\"CPgyVIAPgyVIABUAJAFICkCgAAAAAAAAAApAAAAPigAAEhIB4ACwAKgAZAA8ACAAGQANAAiABPADmAH4AQgA2QDFALzDQAgBsgFpEQAQBsioAQBaQF5jIAIC8x0BQABYAFQAMgAgABkADQAHwARAAngBzAD8AJgAaIA2QCLAFpAMUAdQBMgC8yEAUABYAGQC0gGKAOoSgEAALAAyAEQAbIBaQDFAHUAXmUgHgALAAqABkAEAAMgAaABEACeAHMAPwA0QBsgEWAMUAvMA.YAAAAAAAAIAA\",\"NonTCFVendors\":[{\"id\":1,\"name\":\"Facebook\",\"consent\":false},{\"id\":3,\"name\":\"Google\",\"consent\":false},{\"id\":4,\"name\":\"Chartbeat\",\"consent\":false},{\"id\":5,\"name\":\"Giosg\",\"consent\":false},{\"id\":6,\"name\":\"Hotjar\",\"consent\":false},{\"id\":7,\"name\":\"Qualifio\",\"consent\":false},{\"id\":8,\"name\":\"Questback\",\"consent\":false},{\"id\":9,\"name\":\"Twitter\",\"consent\":false},{\"id\":10,\"name\":\"Wordpress\",\"consent\":false},{\"id\":15,\"name\":\"Linkedin\",\"consent\":false},{\"id\":16,\"name\":\"Microsoft\",\"consent\":false},{\"id\":17,\"name\":\"OneSignal\",\"consent\":false},{\"id\":18,\"name\":\"AppCues\",\"consent\":false},{\"id\":19,\"name\":\"Vimeo\",\"consent\":false},{\"id\":21,\"name\":\"Finnchat\",\"consent\":false},{\"id\":22,\"name\":\"Lekane\",\"consent\":false},{\"id\":23,\"name\":\"Zendesk\",\"consent\":false},{\"id\":24,\"name\":\"Serviceform\",\"consent\":false},{\"id\":25,\"name\":\"Smilee\",\"consent\":false},{\"id\":26,\"name\":\"Calendly\",\"consent\":false},{\"id\":27,\"name\":\"Apple\",\"consent\":false},{\"id\":28,\"name\":\"Cavai\",\"consent\":false},{\"id\":29,\"name\":\"Selligent\",\"consent\":false}]}"
+          },
+          {
+            "name": "__nettix-vendor-consent: \"{\"standardPurpose\":[],\"vendorConsents\"",
+            "value": "{\"1\":false,\"3\":false,\"4\":false,\"5\":false,\"6\":false,\"7\":false,\"8\":false,\"9\":false,\"10\":false,\"11\":false,\"15\":false,\"16\":false,\"17\":false,\"18\":false,\"19\":false,\"21\":false,\"22\":false,\"23\":false,\"24\":false,\"25\":false,\"26\":false,\"27\":false,\"28\":false,\"29\":false,\"30\":false,\"32\":false,\"50\":false,\"52\":false,\"62\":false,\"68\":false,\"71\":false,\"79\":false,\"84\":false,\"91\":false,\"115\":false,\"126\":false,\"130\":false,\"132\":false,\"133\":false,\"152\":false,\"209\":false,\"217\":false,\"264\":false,\"273\":false,\"278\":false,\"290\":false,\"315\":false,\"361\":false,\"385\":false,\"394\":false,\"415\":false,\"468\":false,\"506\":false,\"612\":false,\"729\":false,\"755\":false,\"772\":false,\"994\":false}}"
+          }
+        ]
+      },
+      "id": "7e5d072f-ea5a-4a82-9ea4-3bbf06d5cc8d"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "presence": "div#buttons"
+      },
+      "domain": "actu.fr",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "cto_bundle",
+            "value": "g6Fn9V91SGNrTTNJT29qWlNqbjQlMkZ6eUpEJTJGNnhUbXhQRSUyQnZTR0ZSb0FxY0xVQmV4YVl2WkFpQWxkUHVtVG9IRGVMT3ppUm5tNWFEd0I5NVhmUW1vQXEyUk53cmhnY2tsVjNMNDlUd0twTGdSa3JxWTcweXVDd2RHRlJ3UG1UQVR1MkhrZQ"
+          },
+          {
+            "name": "euconsent-v2",
+            "value": "CPgyVIAPgyVIAAHABBENCkCsAP_AAAAAAAAAIltf_X_db3Nj-_5_fvt0eY1f9dy-v-wjDhedh-0NzXrW-L0F02I7vF3ihggKOQ4EshJBIQdlGKHcRUkw6okEgzGsYESUg4MAJqLEimETGwNYGE1bGURCOAIYrtsoPryymtuKev_1W2V-_-jUQzpJKS-i8IbtQ185xLmsyf0fn4jOP_-VO2997____4AAACQkAGAAIJEBoAMAAQSIEQAYAAgkQKgAwABBIgZABgACCRA6ADAAEEiCEAGAAIJEEoAMAAQSIKQAYAAgkQAA.f_gAAAAAAAAA"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPgyVIAPgyVIAAHABBENCkCgAAAAAAAAAAAAAAAAAAEhIAMAAQSIDQAYAAgkQIgAwABBIgVABgACCRAyADAAEEiB0AGAAIJEEIAMAAQSIJQAYAAgkQUgAwABBIgA.YAAAAAAAAAAA"
+          }
+        ]
+      },
+      "id": "f3b09797-67d8-479d-a369-301955413d65"
+    },
+    {
+      "click": {
+        "optIn": "button.css-11sahre",
+        "presence": "div.qc-cmp2-summary-buttons"
+      },
+      "domain": "sportdog.gr",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "cto_bundle",
+            "value": "9Qphil9ZWTYxVEFFNngyNEpkS1JHYU1lVXRjWFpIVUJkOHpGdjdHNnd6VVRKSmN6ZWNkdElxc1NuOEVRMGNWYzNodnJhdUNhMVFuU2h5MFIlMkJYMENEWTNUc1dzdmM1Q2I4NyUyRlFFNjdCcWJyb1lCeGtYblRiN0hYJTJGTXJLSU9yWFpOTTVaMm1WSmQ4TkZyWVkwJTJGV21IJTJGQWo4d3d3JTNEJTNE"
+          },
+          {
+            "name": "euconsent-v2",
+            "value": "CPgyVIAPgyVIAAKAsAELCkCsAP_AAH_AAAyIJDtd_H__bW9r-f5_aft0eY1P9_r37uQzDhfNk-8F3L_W_LwX52E7NF36tq4KmR4ku1LBIUNlHMHUDUmwaokVryHsak2cpzNKJ7BEknMZOydYGF9vmxtj-QKY7_5_d3bx2D-t_9v239z3z81Xn3d53-_03LCdV5_9Dfn9fR_bc9KPt_58v8v8_____3_e__3_7994JEAEmGrcQBdmWODNoGEUCIEYVhIVQKACCgGFogMAHBwU7KwCfWECABAKAIwIgQ4AowIBAAAJAEhEAEgRYIAAARAIAAQAIhEIAGBgEFgBYGAQAAgGgYohQACBIQZEBEUpgQFQJBAa2VCCUF0hphAHWWAFBIjYqABEEgIrAAEBYOAYIkBKxYIEmKN8gBGCFAKJUK1EAAAA.YAAAAAAAAAAA"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "addtl_consent",
+            "value": "1~"
+          },
+          {
+            "name": "euconsent-v2",
+            "value": "CPgyVIAPgyVIAAKAsAELCkCgAAAAAH_AAAyIAAASIAJMNW4gC7MscGbQMIoEQIwrCQqgUAEFAMLRAYAODgp2VgE-sIEACAUARgRAhwBRgQCAAASAJCIAJAiwQAAAiAQAAgARCIQAMDAILACwMAgABANAxRCgAECQgyICIpTAgKgSCA1sqEEoLpDTCAOssAKCRGxUACIJARWAAICwcAwRICViwQJMUb5ACMEKAUSoVqIAAAAA.YAAAAAAAAAAA"
+          }
+        ]
+      },
+      "id": "74f5fa98-df50-4caf-b1cd-6af3b2812432"
+    },
+    {
+      "click": {
+        "optIn": "button.js-accept",
+        "presence": "div.cookie-banner-buttons"
+      },
+      "domain": "emag.hu",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "EMAGROSESSID",
+            "value": "o0jde53fk36pv9a0fhrj7rlt7f"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "gdpr_consent_type",
+            "value": "1"
+          }
+        ]
+      },
+      "id": "e78a3fdb-bcba-402c-b2da-63994aba1b30"
+    },
+    {
+      "click": {
+        "optIn": "button.css-b2defl",
+        "presence": "div.qc-cmp2-summary-buttons"
+      },
+      "domain": "ilgiornale.it",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "cto_bundle",
+            "value": "ZnPA8F9mTEglMkZlTFJrYUJQdzFrbmlLaGZmNGkwMGZ0S2tXVWgyWno5QXFhbDc3T0JHYVEwbUsxNFljYSUyRnpKUjBhZlRKRHJHdjg4elFjOXRlQjUwMlVTekhRaEMwdTdBSndSZTFpZFMzQ2FsODhJdGREJTJGVUl5VEJsbXBVbTFMOEV2bE1PR2pyM2s1Uzd6WkMxS0JiUWM3WkltZHclM0QlM0Q"
+          },
+          {
+            "name": "euconsent-v2",
+            "value": "CPgyVIAPgyVIAAKAsAITCkCsAP_AAH_AABCYJDtd_H__bW9r-f5_aft0eY1P9_r37uQzDhfNk-8F3L_W_LwX52E7NF36tq4KmR4ku1LBIUNlHMHUDUmwaokVryHsak2cpzNKJ7BEknMZOydYGF9vmxtj-QKY7_5_d3bx2D-t_9v239z3z81Xn3d53-_03LCdV5_9Dfn9fR_bc9KPt_58v8v8_____3_e__3_7994JEAEmGrcQBdmWODNoGEUCIEYVhIVQKACCgGFogMAHBwU7KwCfWECABAKAIwIgQ4AowIBAAAJAEhEAEgRYIAAARAIAAQAIhEIAGBgEFgBYGAQAAgGgYohQACBIQZEBEUpgQFQJBAa2VCCUF0hphAHWWAFBIjYqABEEgIrAAEBYOAYIkBKxYIEmKN8gBGCFAKJUK1EAAAA.f_gAAAAAAAAA"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPgyVIAPgyVIAAKAsBITCkCgAAAAAH_AABCYAAASIAJMNW4gC7MscGbQMIoEQIwrCQqgUAEFAMLRAYAODgp2VgE-sIEACAUARgRAhwBRgQCAAASAJCIAJAiwQAAAiAQAAgARCIQAMDAILACwMAgABANAxRCgAECQgyICIpTAgKgSCA1sqEEoLpDTCAOssAKCRGxUACIJARWAAICwcAwRICViwQJMUb5ACMEKAUSoVqIAAAAA.YAAAAAAAAAAA"
+          },
+          {
+            "name": "addtl_consent",
+            "value": "1~"
+          }
+        ]
+      },
+      "id": "362b64e3-c12d-4d5e-9c8e-169df9782b28"
+    },
+    {
+      "click": {
+        "optIn": "button.sp_choice_type_11",
+        "presence": "div#notice"
+      },
+      "domain": "meczyki.pl",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "cto_bundle",
+            "value": "TUIyPl96bUdna01uanZUQTE0RXJYcFQ1SyUyQlVnSm9GMFVnTTUyd1FPNHF0NlRWZGJ4RGllTGNaV2ttWjlabmk4cnp0V3VUQVB6bVNocGFSYkdXaGJ2T3hUdTB5WGglMkZKcHclMkIyZnpYeGtwY29GU3NwQXFld2d4Z21jVGZVaFNCTHdwNTJudzhFaHcwNE00blpuYVJ0Qmk2TzZhc0ElM0QlM0Q"
+          },
+          {
+            "name": "_pbjs_userid_consent_data",
+            "value": "341412947006878"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "_pbjs_userid_consent_data",
+            "value": "341412947006878"
+          },
+          {
+            "name": "cto_bundle",
+            "value": "9ukUO19oQVVSSmlnJTJGRE9ZMm1MOHZ6UFA5cXl5ODFLQ3BvT1g3d1hyWkMwODhMU1RpQThrUThpckxiREh6NG9HV2FZdWFhWTdkV3piN3lWVG5XcUppJTJCOEc0UFZjbmFKNlV3aDRKUjhTRndQTFAyUzJmM0g3WDJyWFNyYlB3NDRRTzklMkZGVWE3Zk00JTJGSzNCRE9QV2N2NEFhOHJQdyUzRCUzRA"
+          }
+        ]
+      },
+      "id": "39d68e2f-be40-44d6-9f62-c06f0918f831"
+    },
+    {
+      "click": {
+        "optIn": "button.w-button-primary",
+        "presence": "div.w-cookies-popup__footer"
+      },
+      "domain": "worten.pt",
+      "cookies": {},
+      "id": "905b5c20-000d-4b7b-a8d6-d84d2311dfdf"
+    },
+    {
+      "click": {
+        "optIn": "button#CybotCookiebotDialogBodyLevelButtonLevelOptinAllowAll",
+        "optOut": "button#CybotCookiebotDialogBodyButtonDecline",
+        "presence": "div#CybotCookiebotDialog"
+      },
+      "domain": "dobrenoviny.sk",
+      "cookies": {},
+      "id": "22467786-05dc-448c-984a-fe5a2d6c84f8"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "presence": "div#buttons"
+      },
+      "domain": "huffingtonpost.es",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPgyVIAPgyVIAAHABBENCkCsAPfAAAQAAAAAJDtf_X__b3_r-_5___t0eY1f9_7__-0zjhfdl-8N3f_X_L8X_2M7vF36tq4KuR4ku3LBIUdlHOHcTUmw6okVrzPsbk2cr7NKJ7PEmnMbeydYGH9_n1_z-ZKY7___f_77__-____3_____-_f___5______f_V__97fn9_____9_P___9v__9__________3___94I_wJgAhgBMAEcAMsAbQA5gB2ADwAI4AVcArYBYgDeAHVAR6AkUBJwCbAFogLYAXJAvIC84GRAZGAzkBngDPgG1ANvAcSA5IBygDrAH2APwAf6BBsCF4EfwCCUAGAAIJEBoAMAAQSIFAAYAAgkQUgAwABBIgdABgACCRBCADAAEEiAkAGAAIJECIAMAAQSIAA.fvgAAIAAAAAA"
+          },
+          {
+            "name": "cto_bundle",
+            "value": "_xrlhl91YXVQcFlNRDNwZkNvbVFrUk1Oc0lOMXlIcFBuS3ZnNjhhUnVGZEElMkZxMjYlMkJFQSUyRklydVA3YWJtZnRvU2RJVjltSGw2THJQT2dVRkV4UzlsdExIMVozRERqRXFIZ0ZHc1N3T2ZLZEw2aVhmRDJ0UjVldDdzJTJCSGk3b0l6Q3lkWlRIaE8lMkI5STdRTVBWZFFjS0tQMld2cTFRJTNEJTNE"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPgyVIAPgyVIAAHABBENCkCgAAAAAAAAAAAAAAAAAAEEoAMAAQSIDQAYAAgkQKAAwABBIgpABgACCRA6ADAAEEiCEAGAAIJEBIAMAAQSIEQAYAAgkQAA.YAAAAAAAAAAA"
+          }
+        ]
+      },
+      "id": "db80b787-cf15-49ae-bfd6-fcf8777b5c7e"
+    },
+    {
+      "click": {
+        "optIn": "button.css-14ubilm",
+        "presence": "div.qc-cmp2-summary-buttons"
+      },
+      "domain": "tradera.com",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "cto_bundle",
+            "value": "okMPRV9sZXVYa2NJc2RnSzNMSFBZQ1k5RzBQNzVlZ0NRSDZaMFdoMmpEQmZ4S0dDcU9XMmxRckpkeGdwUlN2d0FSbDdZa280czY1enpUNlElMkZIaGdud0FwRDN3b1BlUElmJTJCVVNKa3NCaTFGa1RDR2FZbFBRS3dXWVpzN2x5bmRmYXZSZzlzUzQlMkYxOXRCNk5MMHdnMDVzNTRqQnclM0QlM0Q"
+          },
+          {
+            "name": "gdpr_consent_v1",
+            "value": "1:1,2:1,3:1,4:1"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "addtl_consent",
+            "value": "1~"
+          },
+          {
+            "name": "euconsent-v2",
+            "value": "CPgyVIAPgyVIAAKAsBSVCkCgAAAAAH_AACQgAAASIAJMNW4gC7MscGbQMIoEQIwrCQqgUAEFAMLRAYAODgp2VgE-sIEACAUARgRAhwBRgQCAAASAJCIAJAiwQAAAiAQAAgARCIQAMDAILACwMAgABANAxRCgAECQgyICIpTAgKgSCA1sqEEoLpDTCAOssAKCRGxUACIJARWAAICwcAwRICViwQJMUb5ACMEKAUSoVqIAAAAA.YAAAAAAAAAAA"
+          }
+        ]
+      },
+      "id": "deca4013-d55c-424b-9a46-2df8139fd415"
+    },
+    {
+      "click": {
+        "optIn": "button#onetrust-accept-btn-handler",
+        "presence": "div#onetrust-consent-sdk"
+      },
+      "domain": "rts.ch",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "_gat_UA-176160974-1",
+            "value": "1"
+          },
+          {
+            "name": "_gid",
+            "value": "GA1.2.134968168.1665733255"
+          }
+        ],
+        "optOut": []
+      },
+      "id": "98cea3a5-aba0-4482-932a-0347ccccfb66"
+    },
+    {
+      "click": {
+        "optIn": "button#onetrust-accept-btn-handler",
+        "optOut": "button#onetrust-reject-all-handler",
+        "presence": "div#onetrust-consent-sdk"
+      },
+      "domain": "meinbezirk.at",
+      "cookies": {},
+      "id": "f64c90a8-02fb-449a-9f1c-b6089443eb87"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "presence": "div#buttons"
+      },
+      "domain": "rtl.be",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "_pbjs_userid_consent_data",
+            "value": "3548605541135691"
+          },
+          {
+            "name": "euconsent-v2",
+            "value": "CPg1oEAPg1oEAAHABBENCkCsAP_AAAEAAAIgIJNP_Trdb2Nj-f59dvs0eYxe1dSPp-QwBBaJA2ABwAqAsJQS0mAatATgBIAKKAYEICJBIAJlCCFQTUEQwAEAASGEQACABAIIICIAkEIBCiAICAIDEQgAAAIIgGgCFEAAmwoAQPpCQEBAlAAAIEAAAAoAAADFAgAAAAAAAAgAAAgIAkABBBKBWAAgABYAGQAYgA1ACGAEwAKoAXAAxABmADQAG8AP4AjgBSgDKAHeAPsAigBHACUgFLAKvAWgBaQDAAGKANoAbwA5wB1AEegJBAScAlQBNoCmgFwALkAZ8A1UBygEEgCB0AGAAIJEEoAMAAQSICQAYAAgkQUgAwABBIgVABgACCRAyADAAEEiA0AGAAIJECIAMAAQSIAA.f_gAACAAAAAA"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPg1oEAPg1oEAAHABBENCkCgAAAAAAAAAAIgAAAAAAEDoAMAAQSIJQAYAAgkQEgAwABBIgpABgACCRAqADAAEEiBkAGAAIJEBoAMAAQSIEQAYAAgkQAA.YAAAAAAAAAAA"
+          }
+        ]
+      },
+      "id": "10128014-7abd-4cc2-8dc4-4fc87b64a3df"
+    },
+    {
+      "click": {
+        "optIn": "a.cookies-banner-button",
+        "presence": "div#cookies-banner"
+      },
+      "domain": "dnevnik.bg",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "cookiesAgreement",
+            "value": "1"
+          }
+        ],
+        "optOut": []
+      },
+      "id": "74f56970-6ebe-4802-914e-72aeca0e13b3"
+    },
+    {
+      "click": {
+        "optIn": "a.cookies-button",
+        "presence": "div#cookies-overlay"
+      },
+      "domain": "linker.hr",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "approve",
+            "value": "yes"
+          }
+        ],
+        "optOut": []
+      },
+      "id": "10b58019-5dce-4018-b83d-8eef8c7564a7"
+    },
+    {
+      "click": {
+        "optIn": "a.A",
+        "optOut": "a.R",
+        "presence": "div#CkC"
+      },
+      "domain": "sfr.fr",
+      "cookies": {},
+      "id": "dc867098-30ca-4a28-82b4-71abac243dab"
+    },
+    {
+      "click": {
+        "optIn": "a.cc_btn_accept_all",
+        "presence": "div.cc_banner-wrapper"
+      },
+      "domain": "online-filmek.me",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "cookieconsent_dismissed",
+            "value": "yes"
+          }
+        ],
+        "optOut": []
+      },
+      "id": "c200bbbd-3075-48ee-a507-e5934eb52567"
+    },
+    {
+      "click": {
+        "optIn": "button#onetrust-accept-btn-handler",
+        "presence": "div#onetrust-consent-sdk"
+      },
+      "domain": "irishexaminer.com",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "eupubconsent-v2",
+            "value": "CPg1NsgPg1NsgAcABBENClCsAP_AAH_AAAYgJFBDrT5BIUFAwGBRQAEAEQxDQEAcACAAAACABCABAAAUIAQAAmAIgACABAAAAAYgIDJAIAAECAAAAUAA4AEAAAEAAEAIBAAIAAAAgEAAAAAIAAAAAAAgYAAIgAAAAAAAiAAAAIJCQEAAgAAAAAAAAAAABAAAAgCAAAAAAAJ__9vP___9v-_9__________3_7997BIgAEQVIAAAoCAwIIAAgAAACCAADgAQAAAAQAAAAAAAChACAAgwAAAAAAAAAAADABABAAAABAAEAAAgAHAAIAAAAAAAAAAABAAAAAAgAAAAAAAAAABAECAAAAAAAAAAAEAAIAAAASAgAAAAABAAAAAAAAIAAAAAAAAAAAAAELByHBEgJeLJA8xRvkAIwQoBRKhWogAAA.f_gAD_gAAAAA"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "eupubconsent-v2",
+            "value": "CPg1NsgPg1NsgAcABBENClCgAAAAAH_AAAYgJFBDrT5BIUFAwGBRQAEAEQxDQEAcACAAAACABCABAAAUIAQAAmAIgACABAAAAAYgIDJAIAAECAAAAUAA4AEAAAEAAEAIBAAIAAAAgEAAAAAIAAAAAAAgYAAIgAAAAAAAiAAAAIJCQEAAgAAAAAAAAAAABAAAAgCAAAAAAAJ__9vP___9v-_9__________3_7997BIgAEQVIAAAoCAwIIAAgAAACCAADgAQAAAAQAAAAAAAChACAAgwAAAAAAAAAAADABABAAAABAAEAAAgAHAAIAAAAAAAAAAABAAAAAAgAAAAAAAAAABAECAAAAAAAAAAAEAAIAAAASAgAAAAABAAAAAAAAIAAAAAAAAAAAAAELByHBEgJeLJA8xRvkAIwQoBRKhWogAAA.YAAAD_gAAAAA"
+          }
+        ]
+      },
+      "id": "8003a0d8-e948-4272-865a-e1e9161f389b"
+    },
+    {
+      "click": {
+        "optIn": "button#onetrust-accept-btn-handler",
+        "optOut": "button#onetrust-reject-all-handler",
+        "presence": "div#onetrust-consent-sdk"
+      },
+      "domain": "orange.ro",
+      "cookies": {},
+      "id": "43133f1b-d82c-4d82-840b-31bcee3dc553"
+    },
+    {
+      "click": {
+        "optIn": "a.cmptxt_btn_yes",
+        "presence": "div.cmpboxbtns"
+      },
+      "domain": "alo.rs",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "cto_bundle",
+            "value": "PEQl-F9nY0JYMHZNdWU5U1BhNm41bXhXNTljSXFLeG1aV1I0S0hSQVI1WVRwZjhCaVZacUtTUFpjUCUyQkJhUUZmdE9ZYTVFRCUyRlR5WjJZbjlzeiUyRk0wWFZyd3lmSTAxWGRFeVVFUGpXYTdFdSUyRmJLTjglMkJDYWYwU05DN3B6JTJGOWFMcm13MUtSMQ"
+          },
+          {
+            "name": "_pbjs_userid_consent_data",
+            "value": "6346944235117479"
+          }
+        ],
+        "optOut": []
+      },
+      "id": "4dce4250-5d45-4cf8-bb0c-f485de812859"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "presence": "div#buttons"
+      },
+      "domain": "larazon.es",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPg1oEAPg1oEAAHABBENCkCsAP_AAH_AAAAAJDtf_X__b2_r-_5_f_t0eY1P9_7__-0zjhfdl-8N3f_X_L8X52M7vF36tq4KuR4ku3LBIUdlHOHcTUmw6okVryPsbk2cr7NKJ7PEmnMbOydYGH9_n1_z-ZKY7___f_7z_v-v___3____7-3f3__5___-__e_V__9zfn9_____9vP___9v-_9__________3_7994JCAEmGrcQBdiWOBNtGEUCIEYVhIdQKACigGFogMIHVwU7K4CfWECABAKAIwIgQ4AowYBAAABAEhEQEgR4IBAARAIAAQAKhEIACNgEFABYGAQACgGhYoxQBCBIQZEBEUpgQESJBQT2VCCUH-hphCHWWAFBo_4qEBEoAQrAiEhYOQ4IkBLxZIFmKN8gBGCFAKJUK1AAAAA.f_gAD_gAAAAA"
+          },
+          {
+            "name": "cto_bundle",
+            "value": "oQm4Nl9nSHA5VSUyRk1aS1RvOTFWbWFpaEVpcDJRUlBpeW5Ea01TcllER01FeVBwSER0OEhhV0lJc2Q3ZzhZcllLaVRWMWVhVHZ3V1JrJTJGNjhvbnJ1SXd0Szl2clVXUThOaTlpNWthQk5XRHNYc1M5enQlMkZxOFhXTmZXWXN0YlN5TUJKaXIlMkJ5YkFUMnlRdTFjc0NHbnBvJTJGa2g5TTVRJTNEJTNE"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "aasd",
+            "value": "2%7C1665736972486"
+          }
+        ]
+      },
+      "id": "1365810a-360b-4204-8d09-aeff6ca2149b"
+    },
+    {
+      "click": {
+        "optIn": "button#onetrust-accept-btn-handler",
+        "presence": "div#onetrust-consent-sdk"
+      },
+      "domain": "ikea.com",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "_ga",
+            "value": "GA1.2.299941010.1665737512"
+          }
+        ],
+        "optOut": []
+      },
+      "id": "b2a8aaac-f77d-48b2-85b4-340c99ea831c"
+    },
+    {
+      "click": {
+        "optOut": "a#ensCall",
+        "presence": "div.td-modal-cookie-content"
+      },
+      "domain": "td.com",
+      "cookies": {},
+      "id": "eb274e15-29fe-4004-9e6d-27046bd0b82d"
+    },
+    {
+      "click": {
+        "optIn": "span.a-button-inner",
+        "optOut": "a#sp-cc-rejectall-link",
+        "presence": "span.a-declarative"
+      },
+      "domain": "amazon.fr",
+      "cookies": {},
+      "id": "1653780d-92d7-4677-acb0-6427a7bbdeba"
+    },
+    {
+      "click": {
+        "optIn": "button.fc-cta-consent",
+        "presence": "div.fc-footer-buttons-container"
+      },
+      "domain": "mobile.bg",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "FCNEC",
+            "value": "%5B%5B%22AKsRol-HZQOROXcWlEdDgZQEbUvxfST1zVzLuTo-8HJcZi_1x5knwF_j_x-Sy7iYJ421kbLwsAc_W_pDCXxMV8AkezlQ0Se4_psg1B28BVAo7Tv3RXdkyn1csYKRvnE5fjLug299zvFC3FsG3cPz5FSRf0qmXtp3HQ%3D%3D%22%5D%2Cnull%2C%5B%5D%5D"
+          },
+          {
+            "name": "_pbjs_userid_consent_data",
+            "value": "8477155220263717"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "FCCDCF",
+            "value": "%5Bnull%2Cnull%2Cnull%2C%5B%22CPg1oEAPg1oEAEsABCBGClCgAAAAAAAAAAIwAAAOhQD2F2K2kKEkfjSUWYAQBCujKEIhUAAAAECBIAAAAUgQAgFIIAgAAlACAAAAABAQAQCAgAQABAAAoACgAAAAAAAAAAAAAAQQAABAAIAAAAAAAAEAQAAIAAQAAAAAAABEhCAAQQAEAAAAAAAAAAAAAAAAAAABAAA%22%2C%221~%22%2C%22A7193324-AE65-4BF2-B769-43CD7980AA9B%22%5D%2Cnull%2Cnull%2C%5B%5D%5D"
+          }
+        ]
+      },
+      "id": "3708e6f7-9237-4ef1-8aca-bec748cc676e"
+    },
+    {
+      "click": {
+        "optIn": "buton#CybotCookiebotDialogBodyLevelButtonLevelOptinAllowAll",
+        "optOut": "button#CybotCookiebotDialogBodyButtonDecline",
+        "presence": "div#CybotCookiebotDialogBodyButtons"
+      },
+      "domain": "berlingske.dk",
+      "cookies": {},
+      "id": "d7c0b359-8cdb-433c-b501-6fb2fdad0dc0"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "presence": "div#buttons"
+      },
+      "domain": "20minutes.fr",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPg1oEAPg1oEAAHABBENCkCsAP_AAAAAAAAAIsNf_X_db3tj-_59fvt0eYlf9dy-v-wjBhedh-0NyXvW-L0F02I7vF3ihogKOQgEsjJBIQclGKHcRUkw6okEgyGsYESUg5MAJqLEimETGwNYGE1bGURCOAIYrtsoPryymtuKev_1W2V-_-jUQzpJCS-i8IbtQ185xLmMyf0fn4jOfb-VO29853gAAAAEAAABIqADAAEEiCUAGAAIJEBoAMAAQSIKQAYAAgkQOgAwABBIghABgACCRASADAAEEiBEAGAAIJEDIAMAAQSI.f_gAAAAAAAAA"
+          },
+          {
+            "name": "cto_bundle",
+            "value": "1WCHFF93NHlTaFcwcDVNQ3VtRjV3cVN6TGw3a3FRUWtsRmpTSkR5aFdVaE9GN2w3ckxUU3JSVXpDRVZveFBaWkdnaWhwYlVqS1REc2Uwd05nRHRrUnp0ZXNodDU0YmZPS2xmb3l6ZktCUlF1OEVaWFowSlF4TWFpT09meEFXM2YxUGs5b0lMQ0RSMjJJSThLNFhVeDBhZzBaM0ElM0QlM0Q"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPg1oEAPg1oEAAHABBENCkCgAAAAAAAAAAAAAAAAAAEioAMAAQSIJQAYAAgkQGgAwABBIgpABgACCRA6ADAAEEiCEAGAAIJEBIAMAAQSIEQAYAAgkQMgAwABBIgA.YAAAAAAAAAAA"
+          }
+        ]
+      },
+      "id": "7829c877-7241-4be1-aa6a-628e8d83f61d"
+    },
+    {
+      "click": {
+        "optIn": "button#onetrust-accept-btn-handler",
+        "presence": "div#onetrust-consent-sdk"
+      },
+      "domain": "tripadvisor.it",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "eupubconsent-v2",
+            "value": "CPg1NsgPg1NsgAcABBENClCsAP_AAH_AACiQJFNf_X__b2_r-_5_f_t0eY1P9_7__-0zjhfdl-8N3f_X_L8X52M7vF36tq4KuR4ku3LBIUdlHOHcTUmw6okVryPsbk2cr7NKJ7PEmnMbOydYGH9_n1_z-ZKY7___f_7z_v-v___3____7-3f3__5___-__e_V__9zfn9_____9vP___9v-_9__________3_7997BIgAkw1biALsyxwZtowigRAjCsJDqBQAUUAwtEBhA6uCnZXAT6wgQAIBQBOBECHAFGDAIAABIAkIiAkCPBAIACIBAACABUIhAAxsAgsALAwCAAUA0LFGKAIQJCDIgIilMCAqRIKDeyoQSg_0NMIQ6ywAoNH_FQgI1kDFYEQkLByHBEgJeLJA8xRvkAIwQoBRKhWogAAA.f_gAD_gAAAAA"
+          },
+          {
+            "name": "_pbjs_userid_consent_data",
+            "value": "3226786088262572"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "eupubconsent-v2",
+            "value": "CPg1NsgPg1NsgAcABBENClCgAAAAAAAAACiQAAAAAAAA.YAAAAAAAAAAA"
+          },
+          {
+            "name": "OTAdditionalConsentString",
+            "value": "1~"
+          }
+        ]
+      },
+      "id": "7e537ed5-94dd-43c7-9ad4-c68e96649aba"
+    },
+    {
+      "click": {
+        "optIn": "button#onetrust-accept-btn-handler",
+        "presence": "div#onetrust-consent-sdk"
+      },
+      "domain": "thejournal.ie",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "_gid",
+            "value": "GA1.2.157256800.1665989127"
+          },
+          {
+            "name": "_gat_gtag_UA_17456403_37",
+            "value": "1"
+          }
+        ]
+      },
+      "id": "88d0bf89-ce7e-47f9-9ec2-6eba3b9deed8"
+    },
+    {
+      "click": {
+        "optIn": "button.css-mn27n0",
+        "presence": "div.qc-cmp2-summary-buttons"
+      },
+      "domain": "observador.pt",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPg_g4APg_g4AAKAsAPTClCsAP_AAH_AAB6YJFNd_H__bW9r-f5_aft0eY1P9_r37uQzDhfNk-8F3L_W_LwX52E7NF36tq4KmR4ku1LBIUNlHMHUDUmwaokVryHsak2cpzNKJ7BEknMZOydYGF9vmxtj-QKY7_5_d3bx2D-t_9v239z3z81Xn3d53-_03LCdV5_9Dfn9fR_bc9KPt_58v8v8_____3_e__3_7997BIgAkw1biALsyxwZtAwigRAjCsJCqBQAQUAwtEBgA4OCnZWAT6wgQAIBQBGBECHAFGBAIAABIAkIgAkCLBAAACIBAACABEIhAAwMAgsALAwCAAEA0DFEKAAQJCDIgIilMCAqBIIDWyoQSgukNMIA6ywAoJEbFQAIgkBFYAAgLBwDBEgJWLBAkxRvkAIwQoBRKhWogAAA.YAAAAAAAAAAA"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "addtl_consent",
+            "value": "1~"
+          }
+        ]
+      },
+      "id": "c49fa28b-a67c-42b8-a4e5-4d48d34fba04"
+    },
+    {
+      "click": {
+        "optIn": "div.marginbottom15px",
+        "presence": "div.boton_cookies"
+      },
+      "domain": "aemet.es",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "accept_cookies",
+            "value": "ok"
+          }
+        ],
+        "optOut": []
+      },
+      "id": "60ea2eca-10af-47d1-a240-cbdf44519e9d"
+    },
+    {
+      "click": {
+        "optIn": "button.sp_choice_type_11",
+        "presence": "div#notice"
+      },
+      "domain": "newsnow.co.uk",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPg_g4APg_g4AAGABCENClCgAP_AAH_AACJwI0Nd_X__bX9j-_5_6ft0eY1f9_r37uQzDgfFs-8F3L_W_LwX32E7NF36pq4KmR4EuzLBIQNlHMHUTUmwaokVrzHsak2cpyNKJ7JEknMZe2dYGHtPn9lD-YKY7_5___b52T-9_9_-39T3_8ff__d5_2v_-vDfV599jfn9fV_789LP___9v__8__________wRgAIMBAAgAAEEAEAAAAIQAAQACQAgAAABAABQBIAOCgACFgEAAIQACARAQgAAgBAQAwAAAQAAJAAgBACwQCAACAQAAgABAAAAEBAADACQEAAAEAJCBACAAECAgCAAA5CAAIACCAEIBAAAKJDACAOsoAABBABUAAJAAACAABCwMBwAICVCQABIACgACEEKAWMgLgBDACYAI4AZYBHACrgFbAScAmwBTYC0QFsALzAZGAzkBngDPgGugOUAdwA94CF4EQRECAABwAUABDADIAGWANkAfgBAACMAFPAKuAVkA1gB1QD5AIdASIAmwBOwCkQFNgLkAZGAycBnIDPgGugOUAdYA7gB7wEQQkGIABAAC4AKAAqABkADkAHgAgABgADKAGgAagA8gCGAIoATIAngCgAFUAN4AcwA9AB-AEIAIaARABEgCOAEsAJoAUsAtwC4AGGAMgAZYA2QB3gD2AHxAPsA_QCAAEDAIpARcBGACNAEcAJSAUEAp4BVwCsgFzAMUAaIA1gBtADcAHEAPQAfIBDoCIQEiAJlATYAnYBQ4CkYFNAU2Aq8BYoC0AFsALkAXeAvMBgwDDYGRgZIAycBlwDOQGfANIgawBrIDXQG3gN1AcFA5MDlAHLgOsAdwA8cB7QD3gIQgQvAhoBD0CH4EQQIhgRSCAAQANhoEgADgAuACGAGQAMsAbIA_ACAAEFAIwAU8Aq4BWYC0ALSAawA6oB8gEOgIqASIAmwBOwCkQFNgLkAZGAycBnIDPAGfANdAcoA6wB3AD3gIgioDIAFAAhgBMAC4AI4AZYBHACrwFoAWkBNgCmwFsALkAXmAyMBnIDPAGfANdAbkA5QB3AD3gIXgRBHQdwAFwAUABUADIAHIAPgBAAC6AGAAZQA0ADUAHgAPoAhgCKAEyAJ4AoABVgC4ALoAYgAzABvADmAHoAPwAhoBEAESAJYATAAmgBRgClgFiAWUAtwC4gGEAYYAyABlADRAGyAO8Ae0A-wD9AH-AQMAikBFgEYAI5ASkBKgCggFPAKuAVkAsUBaAFpALmAXWAvIC9AGKANoAbgA4gB1AD0AIdARCAioBF4CRAEqAJkATYAnYBQ8CmgKbAVYAq8BYoC2AFwALkAXaAu8BeYC-gGDAMNAYkAx6BkYGSAMnAZUAywBlwDMwGcgM-AaIA0gBqoDWAGugNvAbqA4uByYHKAOXAdYA7gB44D0gHtAPeAfWA_EB_oEAQINAQvAhpBDkEOgIegRBAikQgiAALAAoABkAFwAMQAagBDACYAFMAKoAXAAxABmADeAHoARwApYBYgFkAMIAd4A-wB_gEUAI4ASkAoIBQwCngFXAKzAWgBaQC5gGKANoAdQA9ACIQEiAJOASoAmyBTQFNgLFAWiAtgBcAC5AF2gMSAZGAycBnIDPAGfANEAaqA10BwADlAHWAO4AeOA94CFAELwIdAQ9AiCSghgAIAAWABQADIAHAAPwAwADEAHgARAAmABQACqAFwAMQAZgBDQCIAIkARwAowBSgCyAFuAMIAbIA7wB-AEcAKeAVcArMBaAFpALqAYoA3AB1AD5AIdARUAi8BIgCbAFUgLFAWwAu0BeYDIwGTgMsAZyAzwBnwDSAGsANdAbeA4AB1gDuAHtAPeAgeBC-CGgIagQ9AiCBFkpBYAAXABQAFQAMgAcgA-AEEAMAAygBoAGoAPIAhgCKAEyAJ4AoABSACqAGIAMwAcwA_ACGgEQARIAowBSwCxALIAW4AwgBlADRAGyAO-AfYB-gEWAIwARwAlIBQQChgFXAKyAVsAuYBeQDFAG0ANwAegBDoCLwEiAJOATYAnYBQ4CmwFigLQAWwAuABcgC7QF5gL6AYbAyMDJAGTgMsAZcAzkBngDPgGkQNYA1kBroDbwG6gOCgcmBygDlwHWAO4AeOA9oB7wEIQIXwQzBDQCHQEPYIgAiCBFIoABAD-AAA.YAAAAAAAAAAA"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPg_g4APg_g4AAGABBENClCgAAAAAH_AACJwAAARgAIMBAAgAAEEAEAAAAIQAAQACQAgAAABAABQBIAOCgACFgEAAIQACARAQgAAgBAQAwAAAQAAJAAgBACwQCAACAQAAgABAAAAEBAADACQEAAAEAJCBACAAECAgCAAA5CAAIACCAEIBAAAKJDACAOsoAABBABUAAJAAACAABCwMBwAICVCQABIACgACEEKACUAAgB_AAAA.YAAAAAAAAAAA"
+          }
+        ]
+      },
+      "id": "9b3af0be-6e22-425b-b34b-8a8120054ab1"
+    },
+    {
+      "click": {
+        "optIn": "button.blue",
+        "presence": "div.cookie-popup"
+      },
+      "domain": "supersport.hr",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "marketing",
+            "value": "1"
+          },
+          {
+            "name": "analytic",
+            "value": "1"
+          }
+        ]
+      },
+      "id": "7eb3fb43-94c5-49da-80ca-1647f8398eec"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "presence": "div#buttons"
+      },
+      "domain": "hn.cz",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "_chartbeat2",
+            "value": ".1666080602371.1666080602371.1.DOUFboBlIHTgKZL30BLuFwxCX94dY.1"
+          },
+          {
+            "name": "_fbp",
+            "value": "fb.1.1666080609206.939474310"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPhCz0APhCz0AAHABBENClCgAAAAAAAAAATIAAAAAACBoAMAAQSKEQAYAAgkUKgAwABBIoZABgACCRQA.YAAAAAAAAAAA"
+          }
+        ]
+      },
+      "id": "bc18d551-2fa6-4143-8dbb-bd669ab31e4d"
+    },
+    {
+      "click": {
+        "optIn": "button#acceptButton",
+        "optOut": "button#declineButton",
+        "presence": "div.coi-button-group"
+      },
+      "domain": "yousee.dk",
+      "cookies": {},
+      "id": "31ef8068-58b4-400b-81cd-a027a16a2305"
+    },
+    {
+      "click": {
+        "optIn": "button.css-k8o10q",
+        "presence": "div.qc-cmp2-summary-buttons"
+      },
+      "domain": "napi.hu",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPhCz0APhCz0AAKAsAHUClCsAP_AAH_AAA6gJFNd_H__bW9r-f5_aft0eY1P9_r37mQzDhfNk-8F3L_W_LwX52E7NF36tq4KmR4Eu1LBIUNlHMHUDUmwaokVryHsak2cpzNKJ7BEknMZOydYGF9vmxtj-QKY7_5_d3bx2D-t_9v239T3z81Xn3d53-_03LCdV5_9Dfn9fR_bc9KPt_58v8v8_____3_e__3_7997BIgAkw1biALsyxwJtAwigRAjCsJCqAQAQUAwtEBgA4OCnZWAT6wgQAIBQBGBECHAFGBAIAABIAgIgAkCDBAAACIBAACABEIhAAwIAgoALAwCAAEA0DFEKAAQBCDIgIiFMCAqBIIDWyoQSgmgNMIAKywAoJAbAAAIgkBFYAAgLBgBBEgJGLBAkxRvkAIwQoBRKhWogAAA.YAAAAAAAAAAA"
+          },
+          {
+            "name": "cto_bundle",
+            "value": "C_6Ty19zTWdWemQ0N2RPUW9XUGNXRngyblVOUUxhbUVYZG1QNVclMkZmWjZ2d3MlMkY4Q3F4VlMzcEFocUhZd2tmUm1uMHUlMkJYT292JTJGM2x1eUZxUHFJYm1icDhnaTJVRmxYUWx4VGZ6YU9rTGNDR25JRmpiR2JLT0ZrWWZtd1BLOEslMkJFN2hadkY"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPhCz0APhCz0AAKAsBHUClCgAAAAAH_AAA6gAAASIAJMNW4gC7MscCbQMIoEQIwrCQqgEAEFAMLRAYAODgp2VgE-sIEACAUARgRAhwBRgQCAAASAICIAJAgwQAAAiAQAAgARCIQAMCAIKACwMAgABANAxRCgAEAQgyICIhTAgKgSCA1sqEEoJoDTCACssAKCQGwAACIJARWAAICwYAQRICRiwQJMUb5ACMEKAUSoVqIAAAAA.YAAAAAAAAAAA"
+          },
+          {
+            "name": "addtl_consent",
+            "value": "1~"
+          }
+        ]
+      },
+      "id": "2b12c85e-4ec0-4a3d-9cbe-9892db3f5850"
+    },
+    {
+      "click": {
+        "optIn": "span.a-button-inner",
+        "optOut": "a#sp-cc-rejectall-link",
+        "presence": "span.a-declarative"
+      },
+      "domain": "amazon.nl",
+      "cookies": {},
+      "id": "ee90b394-e250-4bfb-be64-809458d48c95"
+    },
+    {
+      "click": {
+        "optIn": "button.cmp-intro_acceptAll",
+        "presence": "div.cmp-intro_intro"
+      },
+      "domain": "plejada.pl",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "adpconsent",
+            "value": "CPhEEP0PhEEQ7EYACAENCkCsAP_AAH_AAB5YJENd_H__bX9v-f7_6ft0eY1f9_r37uQzDhfNs-8F3L_W_LwX_2E7NF36tq4KmR4ku1LBIUNtHMnUDUmxaokVrzHsak2cpzNKJ_BkknsZe2dYGF9vm5tj-QKZ7_5_d3f52T_9_9v-39z33913v3d_3-_13Ljd_5_9H_v_fR_bc_Kft_5-_8v8_____3_e______98EiACTDVuIAuxLHAm0DCKBECMKwkKoFABBQDC0QGADg4KdlYBPrCBAAgFAEYEQIcAUYEAgAAAgCQiACQIsEAAAIgEAAIAEQiEABAwCCgAsDAIAAQDQMUQoABAkIMiAiKUwICIEggJbKhBKC6Q0wgDrLACgkRsVAAiAAAVgACAsHAMESAlYsECTFG-QAjBCgFEqFagAAAA.fkAAAbgAAMAA"
+          },
+          {
+            "name": "pubconsent",
+            "value": "npa%3D0%26vendorListVersion%3D164%26cmpTid%3D1746213%26publicationVersion%3D778%26customVendorsConsent%3D1"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "_pbjs_userid_consent_data",
+            "value": "6254855998752291"
+          },
+          {
+            "name": "adpconsent",
+            "value": "CPhEDgsPhEDl_EYACAENCkCgAIAAAH_AAB5YJEQAASIAJMNW4gC7EscCbQMIoEQIwrCQqgUAEFAMLRAYAODgp2VgE-sIEACAUARgRAhwBRgQCAAACAJCIAJAiwQAAAiAQAAgARCIQAEDAIKACwMAgABANAxRCgAECQgyICIpTAgIgSCAlsqEEoLpDTCAOssAKCRGxUACIAABWAAICwcAwRICViwQJMUb5ACMEKAUSoVqAAAA.cAAAAbgAAIAA"
+          }
+        ]
+      },
+      "id": "e7bae4c3-fa09-43e1-92c6-6bcb3cd63b67"
+    },
+    {
+      "click": {
+        "optIn": "button#onetrust-accept-btn-handler",
+        "presence": "div#onetrust-consent-sdk"
+      },
+      "domain": "superbet.ro",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "_tguatd",
+            "value": "eyJ0Z3NvdXJjZSI6IihkaXJlY3QpIn0="
+          },
+          {
+            "name": "_fbp",
+            "value": "fb.1.1666084385648.735386668"
+          }
+        ]
+      },
+      "id": "1305c04d-dcde-42cd-b6bb-ec0dae1e1c9c"
+    },
+    {
+      "click": {
+        "optOut": "button.portal-button",
+        "presence": "div.CookieWall"
+      },
+      "domain": "mozzartsport.com",
+      "cookies": {},
+      "id": "7b299edf-ea10-472a-a3d9-cd622bde1ef9"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "presence": "div#buttons"
+      },
+      "domain": "gong.bg",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "cto_bundle",
+            "value": "j22RkF9wczFJVjh5NkF5RFE1Z3BDMU5RTnlER1JiVlRBWFRXVUxOcDRSaHozZHVJQ0RpJTJGUkFRcFhFN3lLVVcxR3ZCZjNocjZUVklmeEladzV3bDc3VlJEbnpDJTJGJTJCcFlITDlWWldjaWFmbG5lb0NjM2J3WERBb3h2VVMlMkIxSTM4SVAlMkY4JTJCRg"
+          },
+          {
+            "name": "euconsent-v2",
+            "value": "CPhCz0APhCz0AAHABBENClCsAP_AAE7AAAIwGMwFgAFAANAAgABUADoAIAAVAAyABoAEUALYAYQBCAFIATSAo8BUgC4QFygLpAXmAxkC84A4AFQAQAAyABoAEUAQgC8wAg0AGAAIJFCIAMAAQSKA.f_gACdgAAAAA"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPhCz0APhCz0AAHABBENClCgAAAAAAAAAAIwAAAAAABBoAMAAQSKEQAYAAgkUAAA.YAAAAAAAAAAA"
+          },
+          {
+            "name": "_pbjs_userid_consent_data",
+            "value": "7958153601903999"
+          }
+        ]
+      },
+      "id": "6db65d34-6730-43a3-91aa-bcd7608ac38a"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "presence": "div#buttons"
+      },
+      "domain": "extra.cz",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "_gat_UA-134365382-1",
+            "value": "1"
+          }
+        ]
+      },
+      "id": "79a0a4df-9d77-4a45-ac9b-2638338f090a"
+    },
+    {
+      "click": {
+        "optIn": "button.fc-cta-consent",
+        "presence": "div.fc-footer-buttons"
+      },
+      "domain": "telsu.fi",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "FCNEC",
+            "value": "%5B%5B%22AKsRol-SmWE1Zek3oSjihDZo_-sHfz0GVCafvp0zkCi5H2GMAE9xpuf_zkiAxQgzVp1PIBRWGBeeXqkkHwMHRtU1r0lgkddKYGQavJ28LUIDiLAF3hu1JFxIhvMx4JWdlZVA_tAWcGch87e4lJtEv8_p4KkbeaOTGA%3D%3D%22%5D%2Cnull%2C%5B%5D%5D"
+          },
+          {
+            "name": "FCCDCF",
+            "value": "%5Bnull%2Cnull%2Cnull%2C%5B%22CPhCz0APhCz0AEsABBFIClCoAP_AAG_AAApAHQpB7D7FbSFCyP55aLsAMAhXRkCEQqQAAASBAmABQAKQIAQCkkAQFASgBAACAAAgIAJBAQIMCAgACUABQAAAAAEEAAAABAAIIAAAgAEAAAAIAAACAIAAEAAIAAAAEAAAmQhAAIIACAAABAAAAAAAAAAAAAAAAgdCgHsLsVtIUJI_GkoswAgCFdGQIRCoAAAAIECQAAAApAgBAKQQBAABKAEAAAAACAgAgEBAAgACAABQAFAAAAAAAAAAAAAAAggAACAAQAAAAAAAAIAgAAQAAgAAAAAAACJCEAAggAIAAAAAAAAAAAAAAAAAAACAAA.f_gAAAAAAAA%22%2C%221~2072.70.89.93.108.122.149.2202.162.167.196.2253.241.2299.259.2357.311.317.323.2373.338.358.2415.415.449.2506.2526.482.486.494.495.2568.2571.2575.540.574.2624.624.2677.817.827.864.981.1048.1051.1095.1097.1127.1171.1201.1205.1211.1276.1301.1365.1415.1449.1570.1577.1651.1716.1753.1765.1870.1878.1889.1958.2012%22%2C%22F4040C3F-B311-403C-9BDB-2AEA533CCD8D%22%5D%2Cnull%2Cnull%2C%5B%5D%5D"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "FCCDCF",
+            "value": "%5Bnull%2Cnull%2Cnull%2C%5B%22CPhCz0APhCz0AEsABCFIClCgAAAAAAAAAApAAAAOhQD2F2K2kKEkfjSUWYAQBCujIEIhUAAAAECBIAAAAUgQAgFIIAgAAlACAAAAABAQAQCAgAQABAAAoACgAAAAAAAAAAAAAAQQAABAAIAAAAAAAAEAQAAIAAQAAAAAAABEhCAAQQAEAAAAAAAAAAAAAAAAAAABAAA.YAAAAAAAAAA%22%2C%221~%22%2C%22EE7DBC34-5A3A-4088-90DB-A679D6C3A244%22%5D%2Cnull%2Cnull%2C%5B%5D%5D"
+          }
+        ]
+      },
+      "id": "0d950828-684c-48f3-8b0c-3c9523c05fb6"
+    },
+    {
+      "click": {
+        "optIn": "button.css-k8o10q",
+        "presence": "div#qc-cmp2-ui"
+      },
+      "domain": "gossip-tv.gr",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPhCz0APhCz0AAKAsAELClCsAP_AAH_AAAyIJFNd_H__bW9r-f5_aft0eY1P9_r37uQzDhfNk-8F3L_W_LwX52E7NF36tq4KmR4ku1LBIUNlHMHUDUmwaokVryHsak2cpzNKJ7BEknMZOydYGF9vmxtj-QKY7_5_d3bx2D-t_9v239z3z81Xn3d53-_03LCdV5_9Dfn9fR_bc9KPt_58v8v8_____3_e__3_7997BIgAkw1biALsyxwZtAwigRAjCsJCqBQAQUAwtEBgA4OCnZWAT6wgQAIBQBGBECHAFGBAIAABIAkIgAkCLBAAACIBAACABEIhAAwMAgsALAwCAAEA0DFEKAAQJCDIgIilMCAqBIIDWyoQSgukNMIA6ywAoJEbFQAIgkBFYAAgLBwDBEgJWLBAkxRvkAIwQoBRKhWogAAA.d_gACAAAAAAA"
+          },
+          {
+            "name": "_pbjs_userid_consent_data",
+            "value": "3497678886241208"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPhCz0APhCz0AAKAsAELClCgAAAAAH_AAAyIAAASIAJMNW4gC7MscGbQMIoEQIwrCQqgUAEFAMLRAYAODgp2VgE-sIEACAUARgRAhwBRgQCAAASAJCIAJAiwQAAAiAQAAgARCIQAMDAILACwMAgABANAxRCgAECQgyICIpTAgKgSCA1sqEEoLpDTCAOssAKCRGxUACIJARWAAICwcAwRICViwQJMUb5ACMEKAUSoVqIAAAAA.YAAACAAAAAAA"
+          },
+          {
+            "name": "addtl_consent",
+            "value": "1~"
+          }
+        ]
+      },
+      "id": "ba9c17cd-19aa-4fe3-ac0c-9c3055133c5b"
+    },
+    {
+      "click": {
+        "optIn": "button#pt-accept-all",
+        "optOut": "button.pt-tc4",
+        "presence": "div.pt-rAv"
+      },
+      "domain": "liberoquotidiano.it",
+      "cookies": {},
+      "id": "531d8b09-8fce-4019-9f96-31d5add26a43"
+    },
+    {
+      "click": {
+        "optIn": "button.css-19ukivv",
+        "presence": "div#qc-cmp2-ui"
+      },
+      "domain": "vi.nl",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "cto_bundle",
+            "value": "Yipool9EenpScHBFMXp3Tlpjd0xocWxPY2tWRjhSWWxlSmIyQTRDRzIxJTJCcExaaEVBNk03TFVLaUQlMkZWd3h5JTJCOWpkVDdRQVBRMzJxVFo3cTRWaWQyNXk2cHk1NWZvY2tvUm10TFlHNmZCWiUyRnglMkZhJTJCOFBYTCUyRms2c3MxT0NhV0xFZ2phSlo5"
+          },
+          {
+            "name": "cto_bidid",
+            "value": "xajN-19yWFJNYjhCSXBUV2hxb0RyTVdMb2ZWSXVZYXhqQXQxMkpwa3ZpSUZGYm5sTjBZOEJJVFluSTlkMyUyRk9GcEdPejd3V29QdFNEZGttb1ZKa3klMkJUQWt5U2clM0QlM0Q"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPhCz0APhCz0AAKAsDNLClCgAAAAAAAAABpYAAASIgFAA4ACWAZ8BHgCVwGCAO2AdyA8ECRAAAAA.YAAAAAAAAAAA"
+          },
+          {
+            "name": "addtl_consent",
+            "value": "1~"
+          }
+        ]
+      },
+      "id": "5026561f-ffec-437e-bad8-820ac9d55659"
+    },
+    {
+      "click": {
+        "optIn": "button.css-pp-ok",
+        "presence": "div.css-pp-box"
+      },
+      "domain": "sol.no",
+      "cookies": {},
+      "id": "74c880a7-b0c9-451f-8bbb-267888450550"
+    },
+    {
+      "click": {
+        "optIn": "button#onetrust-accept-btn-handler",
+        "presence": "div#onetrust-consent-sdk"
+      },
+      "domain": "g4media.ro",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "eupubconsent-v2",
+            "value": "CPhCZcgPhCZcgAcABBENClCsAP_AAH_AAChQJFNf_X__b2_r-_5_f_t0eY1P9_7__-0zjhfdl-8N3f_X_L8X52M7vF36tq4KuR4ku3LBIUdlHOHcTUmw6okVryPsbk2cr7NKJ7PEmnMbOydYGH9_n1_z-ZKY7___f_7z_v-v___3____7-3f3__5___-__e_V__9zfn9_____9vP___9v-_9__________3_7997BIgAkw1biALsyxwZtowigRAjCsJDqBQAUUAwtEBhA6uCnZXAT6wgQAIBQBOBECHAFGDAIAABIAkIiAkCPBAIACIBAACABUIhAAxsAgsALAwCAAUA0LFGKAIQJCDIgIilMCAqRIKDeyoQSg_0NMIQ6ywAoNH_FQgI1kDFYEQkLByHBEgJeLJA8xRvkAIwQoBRKhWogBEgAIDQigAEBoQA.f_gAD_gAAAAA"
+          },
+          {
+            "name": "cto_bundle",
+            "value": "XdCPZF9jcHE5aWZXVk1KV1NqajV3Mkhmd3hwcGtkJTJCZ3ZHbXozTm12cUozSXdKT29xYzZOVDBKdzZFT1NZNUhJRFNobzhoMTY4SnVhYjkwbklvTko4Rm9pRlVxMm4xTTFJVEZsc3ZiTndIQm1lY2ZSYWptNTQzaTQxRiUyQmZ1SEc5ZU00ektpMkgwYlAwV09OWmVLUnpPaTk0ZnFnJTNEJTNE"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "_pbjs_userid_consent_data",
+            "value": "3715683430125761"
+          }
+        ]
+      },
+      "id": "47710996-3372-4d61-a86d-21ee6dfac8d4"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "presence": "div#didomi-popup"
+      },
+      "domain": "okdiario.com",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPhCz0APhCz0AAHABBENClCsAP_AAH_AAAAAJFNf_X__b2_r-_5_f_t0eY1P9_7__-0zjhfdl-8N3f_X_L8X52M7vF36tq4KuR4ku3LBIUdlHOHcTUmw6okVryPsbk2cr7NKJ7PEmnMbOydYGH9_n1_z-ZKY7___f_7z_v-v___3____7-3f3__5___-__e_V__9zfn9_____9vP___9v-_9__________3_7997BIQAkw1biALsSxwJtowigRAjCsJDqBQAUUAwtEBhA6uCnZXAT6wgQAIBQBGBECHAFGDAIAAAIAkIiAkCPBAIACIBAACABUIhAARsAgoALAwCAAUA0LFGKAIQJCDIgIilMCAiRIKCeyoQSg_0NMIQ6ywAoNH_FQgIlACFYEQkLByHBEgJeLJAsxRvkAIwQoBRKhWoAAAA.f_gAD_gAAAAA"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPhCz0APhCz0AAHABBENClCgAAAAAAAAAAAAAAAAAAAA.YAAAAAAAAAAA"
+          }
+        ]
+      },
+      "id": "7157753a-13f1-49e9-a695-d471ae56c3d8"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "presence": "div#buttons"
+      },
+      "domain": "dhnet.be",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPhCz0APhCz0AAHABBENClCgAAAAAAAAAAAAAAAAAAAA.YAAAAAAAAAAA"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPhCz0APhCz0AAHABBENClCgAAAAAAAAAAAAAAAAAAAA.YAAAAAAAAAAA"
+          },
+          {
+            "name": "_pbjs_userid_consent_data",
+            "value": "5021550117542924"
+          }
+        ]
+      },
+      "id": "6716fe34-faf2-43ce-950a-ed7d6b170299"
+    },
+    {
+      "click": {
+        "optIn": "button.fc-cta-consent",
+        "presence": "div.fc-footer-buttons"
+      },
+      "domain": "news.bg",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "cto_bundle",
+            "value": "F_Fs9V9HMWx0JTJCVk1oVGROWkZ1SFUlMkY5N2l6byUyQm9wNmd5bjZBY0EwYTdFcVplZnpYUnQwc2VkRThSQ3N0NUNWRW5NbUtickRXZlQyJTJGMzJHcXRoUnltRjJEdmgzJTJCRkxWQ2FBWngxcDNCVzFvZHpMYUREVHlUdGs2STFnM1JOUzVCZXNOZXA"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "FCCDCF",
+            "value": "%5Bnull%2Cnull%2Cnull%2C%5B%22CPhCz0APhCz0AEsABCBGClCgAAAAAAAAAAIwAAAQvQD-F2K2lKGkfjaUeYIQBKujOEIhUBgEAEKBIQAEA0gQAgFIIAgADlgCUAAAABARCQCAgAQABAAAoICgAAAAACAAAABAASQQAABAAIAAICAABAUBQAAIAARAAgAAMBBEhDAASSAECAAAAAACAAIAAAAAAAABAAAAAAAAAIAAAAAAAAAAAAAEAAA.YAAAAAAAAAA%22%2C%221~%22%2C%22924A9049-E66F-4E81-92F6-E6AE4366B6B6%22%5D%2Cnull%2Cnull%2C%5B%5D%5D"
+          }
+        ]
+      },
+      "id": "1a473c52-96a0-4d12-a8cd-d12d1cc8edca"
+    },
+    {
+      "click": {
+        "optIn": "button.css-k8o10q",
+        "presence": "div#qc-cmp2-ui"
+      },
+      "domain": "zougla.gr",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "_pbjs_userid_consent_data",
+            "value": "3524755945110770"
+          },
+          {
+            "name": "euconsent-v2",
+            "value": "CPhGGwAPhGGwAAKAsAELClCsAP_AAH_AAAyIJFNd_H__bW9r-f5_aft0eY1P9_r37uQzDhfNk-8F3L_W_LwX52E7NF36tq4KmR4ku1LBIUNlHMHUDUmwaokVryHsak2cpzNKJ7BEknMZOydYGF9vmxtj-QKY7_5_d3bx2D-t_9v239z3z81Xn3d53-_03LCdV5_9Dfn9fR_bc9KPt_58v8v8_____3_e__3_7997BIgAkw1biALsyxwZtAwigRAjCsJCqBQAQUAwtEBgA4OCnZWAT6wgQAIBQBGBECHAFGBAIAABIAkIgAkCLBAAACIBAACABEIhAAwMAgsALAwCAAEA0DFEKAAQJCDIgIilMCAqBIIDWyoQSgukNMIA6ywAoJEbFQAIgkBFYAAgLBwDBEgJWLBAkxRvkAIwQoBRKhWogAAA.YAAAAAAAAAAA"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "_pbjs_userid_consent_data",
+            "value": "3524755945110770"
+          },
+          {
+            "name": "euconsent-v2",
+            "value": "CPhGGwAPhGGwAAKAsAELClCgAAAAAH_AAAyIAAASIAJMNW4gC7MscGbQMIoEQIwrCQqgUAEFAMLRAYAODgp2VgE-sIEACAUARgRAhwBRgQCAAASAJCIAJAiwQAAAiAQAAgARCIQAMDAILACwMAgABANAxRCgAECQgyICIpTAgKgSCA1sqEEoLpDTCAOssAKCRGxUACIJARWAAICwcAwRICViwQJMUb5ACMEKAUSoVqIAAAAA.YAAAAAAAAAAA"
+          }
+        ]
+      },
+      "id": "0587a3cf-e084-40bf-b01a-2586c2313f3b"
+    },
+    {
+      "click": {
+        "optIn": "button.css-1al1vdb",
+        "presence": "div#qc-cmp2-ui"
+      },
+      "domain": "calciomercato.com",
+      "cookies": {
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPhGGwAPhGGwAAKAsBITClCgAAAAAH_AABCYAAASIAJMNW4gC7MscGbQMIoEQIwrCQqgUAEFAMLRAYAODgp2VgE-sIEACAUARgRAhwBRgQCAAASAJCIAJAiwQAAAiAQAAgARCIQAMDAILACwMAgABANAxRCgAECQgyICIpTAgKgSCA1sqEEoLpDTCAOssAKCRGxUACIJARWAAICwcAwRICViwQJMUb5ACMEKAUSoVqIAAAAA.YAAAAAAAAAAA"
+          },
+          {
+            "name": "addtl_consent",
+            "value": "1~"
+          }
+        ]
+      },
+      "id": "68c6fe41-fb1d-41ed-a8c6-55fde975f0ab"
+    },
+    {
+      "click": {
+        "optIn": "a#consent_prompt_submit",
+        "presence": "div.global-overlay-content"
+      },
+      "domain": "telenor.no",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "CONSENTMGR",
+            "value": "consent:true%7Cts:1666183380115"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "CONSENTMGR",
+            "value": "c1:0%7Cc6:0%7Cts:1666183304450%7Cconsent:false"
+          }
+        ]
+      },
+      "id": "4ed03d1e-155c-45fa-a8c9-fbccc9ac0f33"
+    },
+    {
+      "click": {
+        "optIn": "button#onetrust-accept-btn-handler",
+        "presence": "div#onetrust-consent-sdk"
+      },
+      "domain": "wyborcza.pl",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "eupubconsent-v2",
+            "value": "CPhFsYgPhFsYgAcABBENClCsAP_AAH_AAAYgJFNf_X__b2_r-_5_f_t0eY1P9_7__-0zjhfdl-8N3f_X_L8X52M7vB36tq4KuR4ku3LBIUdlHOHcTUmw6okVryPsbk2cr7NKJ7PEmnMbOydYGH9_n1_z-ZKY7___f_7z_v-v___3____7-3f3__5___-__e_V__9zfn9_____9vP___9v-_9__________3_7997BIgAkw1biALsyxwZtowigRAjCsJDqBQAUUAwtEBhA6uCnZXAT6wgQAIBQBOBECHAFGDAIAABIAkIiAkCPBAIACIBAACABUIhAAxsAgsALAwCAAUA0LFGKAIQJCDIgIilMCAqRIKDeyoQSg_0NMIQ6ywAoNH_FQgI1kDFYEQkLByHBEgJeLJA8xRvkAIwQoBRKhWogAAA.f_gAD_gAAAAA"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "eupubconsent-v2",
+            "value": "CPhFsYgPhFsYgAcABBENClCgAAAAAH_AAAYgAAASIAJMNW4gC7MscGbaMIoEQIwrCQ6gUAFFAMLRAYQOrgp2VwE-sIEACAUATgRAhwBRgwCAAASAJCIgJAjwQCAAiAQAAgAVCIQAMbAILACwMAgAFANCxRigCECQgyICIpTAgKkSCg3sqEEoP9DTCEOssAKDR_xUICNZAxWBEJCwchwRICXiyQPMUb5ACMEKAUSoVqIAAAAA.YAAAD_gAAAAA"
+          },
+          {
+            "name": "OTAdditionalConsentString",
+            "value": "1~"
+          }
+        ]
+      },
+      "id": "24fa4c95-a6f8-4479-a3a6-a5fe2080a8ae"
+    },
+    {
+      "click": {
+        "optIn": "div._euwdl0",
+        "presence": "footer._nlniiu"
+      },
+      "domain": "2gis.ru",
+      "cookies": {},
+      "id": "2a737c68-b3ed-4883-b02e-4cff18b538b4"
+    },
+    {
+      "click": {
+        "optIn": "button#onetrust-accept-btn-handler",
+        "optOut": "button#onetrust-reject-all-handler",
+        "presence": "div#onetrust-consent-sdk"
+      },
+      "domain": "ica.se",
+      "cookies": {},
+      "id": "c91bdc96-3eda-48ae-9aa2-ddd91806ed67"
+    },
+    {
+      "click": {
+        "optIn": "button#accept-privacy-policies",
+        "presence": "div.emb38ba0"
+      },
+      "domain": "walmart.ca",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "s_sq",
+            "value": "wmicanadaprod%3D%2526c.%2526a.%2526activitymap.%2526page%253DHome%252520Page%2526link%253DClose%2526region%253DBODY%2526pageIDType%253D1%2526.activitymap%2526.a%2526.c%2526pid%253DHome%252520Page%2526pidt%253D1%2526oid%253Dfunctiongr%252528%252529%25257B%25257D%2526oidt%253D2%2526ot%253DSUBMIT"
+          },
+          {
+            "name": "wmicanadaprod%3D%2526c.%2526a.%2526activitymap.%2526page%253DHome%252520Page%2526link%253DClose%2526region%253DBODY%2526pageIDType%253D1%2526.activitymap%2526.a%2526.c%2526pid%253DHome%252520Page%2526pidt%253D1%2526oid%253Dfunctiongr%252528%252529%25257B%25257D%2526oidt%253D2%2526ot%253DSUBMIT",
+            "value": "true"
+          }
+        ]
+      },
+      "id": "0485cf43-5df0-41aa-83da-92cd3b82d6f7"
+    },
+    {
+      "click": {
+        "optIn": "button#onetrust-accept-btn-handler",
+        "presence": "div#onetrust-consent-sdk"
+      },
+      "domain": "nachrichten.at",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "eupubconsent-v2",
+            "value": "CPhFsYgPhFsYgAcABBENClCsAP_AAAAAAChQIpNR_T7VLWHj6f5_dvskOI1P1sTPB-QDDhaBA-AFCXOQ8IwGwmEatASgBigCIQIkohJBIABEDAEECUAA4IgBAAGMAgEABAAKICJAiAEDCQMIAEgKCAAQAQAIgEAtCESAugiAKLKEGGEQpAAADIBAAAgACIABAgIAAAAAAAAAAAAAAICAAAAAAAAAAAEAAAAwSACAvMVABAXmMgAgLzHQAQF5koAIC8ykAEBeYAAA.f_gAAAAAAAAA"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "eupubconsent-v2",
+            "value": "CPhFsYgPhFsYgAcABBENClCgAAAAAAAAAChQAAAAAADBIAIC8xUAEBeYyACAvMdABAXmSgAgLzKQAQF5gAAA.YAAAAAAAAAAA"
+          }
+        ]
+      },
+      "id": "ce5eae3b-5165-4c07-97f7-9edfc2a4cfa0"
+    },
+    {
+      "click": {
+        "optIn": "button.btn-cta-lg",
+        "optOut": "button.btn-secondary-lg",
+        "presence": "div.cookie-button-container"
+      },
+      "domain": "roblox.com",
+      "cookies": {},
+      "id": "1e55c3c3-63d2-45b2-8871-dfae1396c1a0"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "optOut": "span.didomi-continue-without-agreeing",
+        "presence": "div#didomi-popup"
+      },
+      "domain": "leparisien.fr",
+      "cookies": {},
+      "id": "f52698f6-efc9-4a8d-a425-e0e147a98c42"
+    },
+    {
+      "click": {
+        "optIn": "button.css-1hzdrx2",
+        "presence": "div.qc-cmp2-summary-buttons"
+      },
+      "domain": "newsbeast.gr",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "cto_bundle",
+            "value": "hRwg-F9hazQ4NWh4Q2VZQURIZEdKVUVBMXNpcDZxMk9IejdiN3BNUnJ5TWtrMGtQOTZVWEl6ZktQcDlmMDZuQkhhczVQc0xwcEFVenFxSmF5czFJakU0V1dabzZVOSUyQjd6ZzZwUmhxS3pkYUMlMkZSSW1JcTRFWk1jJTJGYjFaN1pEWlduM1Vkeg"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "addtl_consent",
+            "value": "1~"
+          },
+          {
+            "name": "euconsent-v2",
+            "value": "CPhGGwAPhGGwAAKAsAELClCgAAAAAH_AAAyIAAASIAJMNW4gC7MscGbQMIoEQIwrCQqgUAEFAMLRAYAODgp2VgE-sIEACAUARgRAhwBRgQCAAASAJCIAJAiwQAAAiAQAAgARCIQAMDAILACwMAgABANAxRCgAECQgyICIpTAgKgSCA1sqEEoLpDTCAOssAKCRGxUACIJARWAAICwcAwRICViwQJMUb5ACMEKAUSoVqIAAAAA.YAAAAAAAAAAA"
+          }
+        ]
+      },
+      "id": "b9fd5871-876d-4931-9f76-dd695e613919"
+    },
+    {
+      "click": {
+        "optIn": "button.iubenda-cs-accept-btn",
+        "optOut": "button.iubenda-cs-reject-btn",
+        "presence": "div#iubenda-cs-banner"
+      },
+      "domain": "giallozafferano.it",
+      "cookies": {},
+      "id": "65638975-8222-425c-9be0-3f41a51db13c"
+    },
+    {
+      "click": {
+        "optIn": "button.rodo-popup-agree",
+        "presence": "div.rodo-popup-buttons"
+      },
+      "domain": "pomponik.pl",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "_pbjs_userid_consent_data",
+            "value": "3977206233479728"
+          },
+          {
+            "name": "cto_bundle",
+            "value": "SFc7jV9Eb0pLaEdqTEtEOHFGMjdDJTJGYzJsdHJnSW1DdnV1ZWQ3ZmJ1QWlQYVlBUGFUcTAycjJ1UHpmQjA3eUxnZHM3Uk1kVWlmVXgxWmlzakt6b1hJcUUzcHFrb2RvcCUyRnh6WldmY0UxQjJIcXJDdmdLZCUyRnZHZlQ1eFpKeEZmemNidnRYdXgxQXRVTiUyRjZQZ0dleGRydFdvVUlCZyUzRCUzRA"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "_pbjs_userid_consent_data",
+            "value": "5610641117693523"
+          }
+        ]
+      },
+      "id": "397fdd1a-d6b7-4bab-a105-3f1f36f755ff"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "presence": "div#buttons"
+      },
+      "domain": "lecturas.com",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "cto_bundle",
+            "value": "EN0kEV8lMkZCUFlEMlpxJTJGbzEyNmdPRk5OTUs4RXZpa3hkbjI1WFlMVkZrcXEyOUdrbW5hMzJUaTFpVmtNUnVzWk5hJTJCZnpIa3pOYjJCeVd3c3BMejdmTUc1YlllJTJGN1lac1dwdzJ3OXBINlhxJTJCMmtGRnZsd20lMkZndm1xYjJlc3d0VyUyQlZ5N1EyN2JmYXN2UjBYY1VKZWNBUk9JaEFJdyUzRCUzRA"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPhGGwAPhGGwAAHABBENClCgAAAAAAAAAAAAAAAAAAEkIAMAAQSKJQAYAAgkUMgAwABBIoVABgACCRRSADAAEEih0AGAAIJFBIAMAAQSKEQAYAAgkUGgAwABBIoA.YAAAAAAAAAAA"
+          }
+        ]
+      },
+      "id": "b9e08a2f-273d-43c5-9808-22867994b07f"
+    },
+    {
+      "click": {
+        "optIn": "button.aza-cta-button",
+        "presence": "div.cookie-banner-content"
+      },
+      "domain": "avanza.se",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "AZACOOKIECONSENT_ANALYSIS",
+            "value": "YES"
+          },
+          {
+            "name": "AZACOOKIECONSENT_MARKETING",
+            "value": "YES"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "AZACOOKIECONSENT_MARKETING",
+            "value": "NO"
+          },
+          {
+            "name": "AZACOOKIECONSENT_ANALYSIS",
+            "value": "NO"
+          }
+        ]
+      },
+      "id": "803fbd5e-3734-4cf6-a878-5ffe24ec6809"
+    },
+    {
+      "click": {
+        "optIn": "button#consent_prompt_submit",
+        "presence": "div.ppm-cookie-banner__action"
+      },
+      "domain": "post.ch",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "consentprompt",
+            "value": "yes"
+          }
+        ]
+      },
+      "id": "c40f3982-0372-4cdd-8aea-c150afd8328e"
+    },
+    {
+      "click": {
+        "optIn": "button.sp_choice_type_11",
+        "presence": "div.message-component"
+      },
+      "domain": "news.sky.com",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "cto_bundle",
+            "value": "H_ot3V9VODlLa3ZoU1VNTllvTlcxa2JZQ1VXNiUyRnl1N3JBRDdVR0c0ZHBMJTJGdE9FbWJyTGFXU2t5UXlScXJkN3NhVkxYY3dkJTJGS2ZqM2NDNG95bTdyQ0Yzd3BHWkRUZ2ZuR3g0cWNtbzZDV2JqNjNSMUxsUiUyRjZzcmolMkIlMkZmajB6MXRrQ25uaw"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPhJZsAPhJZsAAGABBENClCgAAAAAAAAACJwAAAAAAAA.YAAAAAAAAAAA"
+          }
+        ]
+      },
+      "id": "75a18e16-cde2-4c20-9504-f64c91a4e75e"
+    },
+    {
+      "click": {
+        "optIn": "button.fc-button",
+        "presence": "div.fc-footer-buttons-container"
+      },
+      "domain": "accuweather.com",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "cto_bundle",
+            "value": "ZzZAWF95S0xRTmVqSWZReEJxaTZhZloxWVBVblNZMzJubXhtTjlmdTJOdWo4Tk1uWXlNOGllM3dHWUpNZm85YVhnYmI5M3dDclZmUDZLUnB0Rkw3MGdrdzBPeHY3byUyQjE2d3h0SndxU2ZuVDg2TG81V25YNno1WE1MRWNaRXkxbEFKVWRlV1pIZVBQclM4VDA2aXVsJTJGeFpHc2JRJTNEJTNE"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "FCCDCF",
+            "value": "%5Bnull%2Cnull%2Cnull%2C%5B%22CPhJZsAPhJZsAEsABCENClCgAAAAAAAAACiQAAAOhQD2F2K2kKGkfjSUWYgQBCujIEIhUAABAECBIAAAAUgQAgFIIAiAAlACBAAAABAQAQCAgAQABAAAoACgAAAAAAAAAAAAAAQQAABAAIAAAAAAAAEAQAAIAARAAAAAAABEhCAAQQAkBAAAAAAAAAAAAAAAAAABAAA%22%2C%221~%22%2C%226210ED75-AF63-4379-A563-0C22C82F941A%22%5D%2Cnull%2Cnull%2C%5B%5D%5D"
+          },
+          {
+            "name": "awxconsent",
+            "value": "1"
+          }
+        ]
+      },
+      "id": "60f526aa-abb2-4930-bec4-7113af7481ae"
+    },
+    {
+      "click": {
+        "optIn": "button#onetrust-accept-btn-handler",
+        "presence": "div#onetrust-consent-sdk"
+      },
+      "domain": "tt.com",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "eupubconsent-v2",
+            "value": "CPhI_UgPhI_UgAcABBENClCsAP_AAH_AAChQJFNf_X__b2_r-_5_f_t0eY1P9_7__-0zjhfdl-8N3f_X_L8X52M7vF36tq4KuR4ku3LBIUdlHOHcTUmw6okVryPsbk2cr7NKJ7PEmnMbOydYGH9_n1_z-ZKY7___f_7z_v-v___3____7-3f3__5___-__e_V__9zfn9_____9vP___9v-_9__________3_7997BIgAkw1biALsyxwZtowigRAjCsJDqBQAUUAwtEBhA6uCnZXAT6wgQAIBQBOBECHAFGDAIAABIAkIiAkCPBAIACIBAACABUIhAAxsAgsALAwCAAUA0LFGKAIQJCDIgIilMCAqRIKDeyoQSg_0NMIQ6ywAoNH_FQgI1kDFYEQkLByHBEgJeLJA8xRvkAIwQoBRKhWogAAA.f_gAD_gAAAAA"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "eupubconsent-v2",
+            "value": "CPhI_UgPhI_UgAcABBENClCgAAAAAH_AAChQJFNf_X__b2_r-_5_f_t0eY1P9_7__-0zjhfdl-8N3f_X_L8X52M7vF36tq4KuR4ku3LBIUdlHOHcTUmw6okVryPsbk2cr7NKJ7PEmnMbOydYGH9_n1_z-ZKY7___f_7z_v-v___3____7-3f3__5___-__e_V__9zfn9_____9vP___9v-_9__________3_7997BIgAkw1biALsyxwZtowigRAjCsJDqBQAUUAwtEBhA6uCnZXAT6wgQAIBQBOBECHAFGDAIAABIAkIiAkCPBAIACIBAACABUIhAAxsAgsALAwCAAUA0LFGKAIQJCDIgIilMCAqRIKDeyoQSg_0NMIQ6ywAoNH_FQgI1kDFYEQkLByHBEgJeLJA8xRvkAIwQoBRKhWogAAA.YAAAD_gAAAAA"
+          }
+        ]
+      },
+      "id": "0d21b563-dcb9-4389-ba2c-f6f9cd640515"
+    },
+    {
+      "click": {
+        "optIn": "button.fc-button",
+        "presence": "div.fc-footer-buttons"
+      },
+      "domain": "klik.hr",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "FCNEC",
+            "value": "%5B%5B%22AKsRol8n1sRGaWj3DZsGv3P802g_HWVWfo3HoGdhNOUoao4aMSxgdgJVoS4LbcPyZHMLABOdD-iYEJ5iOns-QN2TqE0Ib0lPXMkxrXlKAyu57IIoq4LZXE0I5oM5qKL46CxolQda4urPU1XllYEN28PcGgzMxE0Dtg%3D%3D%22%5D%2Cnull%2C%5B%5D%5D"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "UA_ADS",
+            "value": "{\"/88449691,7691969/jedanklik.hr/home_970x250_v1\":4,\"/88449691,7691969/jedanklik.hr/home_970x250_v2\":5,\"/88449691,7691969/jedanklik.hr/home_970x250_v4\":5,\"/88449691,7691969/jedanklik.hr/content_v1\":5,\"/88449691,7691969/jedanklik.hr/content_v2\":5,\"/88449691,7691969/jedanklik.hr/content_v3\":5,\"/88449691,7691969/jedanklik.hr/content_v4\":5,\"/88449691,7691969/jedanklik.hr/content_v5\":5,\"/88449691,7691969/jedanklik.hr/home_300x250_v2\":4,\"/88449691,7691969/jedanklik.hr/home_300x250_v3\":4,\"/88449691,7691969/jedanklik.hr/home_300x250_v4\":5,\"/88449691,7691969/jedanklik.hr/banner_300x250_v1\":5,\"/88449691,7691969/jedanklik.hr/home_300x600_v1\":5,\"/88449691,7691969/jedanklik.hr/home_300x600_v2\":5,\"/88449691,7691969/jedanklik.hr/home_300x600_v3\":5,\"/88449691,7691969/jedanklik.hr/home_970x90_v1\":4,\"/88449691,7691969/jedanklik.hr/home_970x250_v3\":5,\"/88449691,7691969/jedanklik.hr/home_300x250_v5\":5}"
+          }
+        ]
+      },
+      "id": "da442430-1131-4e32-93c7-2c3710d723d1"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "optOut": "button#didomi-notice-disagree-button",
+        "presence": "div#buttons"
+      },
+      "domain": "doctolib.fr",
+      "cookies": {},
+      "id": "690aa076-4a8b-48ec-b52c-1443d44ff008"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "presence": "div#buttons"
+      },
+      "domain": "hasznaltauto.hu",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPhJZsAPhJZsAAHABBENClCsAP_AAH_AAA6gI_tf_X__b2_j-_5_f_t0eY1P9_7__-0zjhfdl-8N3f_X_L8X52M7vF36tq4KuR4ku3LBIQdlHOHcTUmw6okVryPsbk2cr7NKJ7PEmnMbOydYGH9_n1_z-ZKY7___f_7z_v-v___3____7-3f3__5___-__e_V__9zfn9_____9vP___9v-_9__________3_79gj-ASYatxAF2JY4E20YRQIgRhWEh1AoAKKAYWiAwgdXBTsrgJ9YQIAEAoAjAiBDgCjBgEAAAEASERASBHggEABEAgABAAqEQgAI2AQUAFgYBAAKAaFijFAEIEhBkQERSmBARIkFBPZUIJQf6GmEIdZYAUGj_ioQESgBCsCISFg5DgiQEvFkgWYo3yAEYIUAolQqAAA.f_gAD_gAAAAA"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPhJZsAPhJZsAAHABBENClCgAAAAAAAAAA6gAAAAAAAA.YAAAAAAAAAAA"
+          }
+        ]
+      },
+      "id": "70df43a6-95e0-4a16-8a02-4be0006fd909"
+    },
+    {
+      "click": {
+        "optIn": "button#onetrust-accept-btn-handler",
+        "presence": "div#onetrust-consent-sdk"
+      },
+      "domain": "three.ie",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "_fbp",
+            "value": "fb.1.1666255793736.392043775"
+          }
+        ]
+      },
+      "id": "30ac8c7a-c31d-43c7-bc6d-9b4202c1cde1"
+    },
+    {
+      "click": {
+        "optIn": "button#onetrust-accept-btn-handler",
+        "optOut": "button#onetrust-reject-all-handler",
+        "presence": "div#onetrust-consent-sdk"
+      },
+      "domain": "flashscore.pl",
+      "cookies": {},
+      "id": "676be8dd-e8c6-41c4-95c8-c2f96fd4f282"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "presence": "div#buttons"
+      },
+      "domain": "zerozero.pt",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "cto_bundle",
+            "value": "6aLX919zWVViT3VtakgxJTJCTkVEcmJ1TE5QV1VUWFhkVyUyQmo2RzlNek0lMkJ1QWJ3V3BpdHYlMkJsYk9reUVBeVBTUUNwUTE0MWFpRkZyd3BYNTZRJTJGSHcxMWZVVDc2T3AzSlpTdkVIQlFHUFE0b1piZnBGNEhrZWJsS0RKcHl5T0ZJSWo1ZHMzVTliY1RDUHRZU1gyUlpBbmVPVjdRNlBBJTNEJTNE"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPhJZsAPhJZsAAHABBENClCgAAAAAH_AAB6YAAASEAJMNW4gC7EscCbaMIoEQIwrCQ6gUAFFAMLRAYQOrgp2VwE-sIEACAUARgRAhwBRgwCAAACAJCIgJAjwQCAAiAQAAgAVCIQAEbAIKACwMAgAFANCxRigCECQgyICIpTAgIkSCgnsqEEoP9DTCEOssAKDR_xUICJQAhWBEJCwchwRICXiyQLMUb5ACMEKAUSoVqAA.YAAAD_gAAAAA"
+          }
+        ]
+      },
+      "id": "1a37cced-b12a-44d9-a576-d1b259312471"
+    },
+    {
+      "click": {
+        "optIn": "button.css-47sehv",
+        "presence": "div.qc-cmp2-summary-buttons"
+      },
+      "domain": "cancan.ro",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "__qca",
+            "value": "P0-1357318454-1666256367279"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "addtl_consent",
+            "value": "1~"
+          },
+          {
+            "name": "euconsent-v2",
+            "value": "CPhJZsAPhJZsAAKAsBROClCgAAAAAH_AACJwAAASIAJMNW4gC7MscGbQMIoEQIwrCQqgUAEFAMLRAYAODgp2VgE-sIEACAUARgRAhwBRgQCAAASAJCIAJAiwQAAAiAQAAgARCIQAMDAILACwMAgABANAxRCgAECQgyICIpTAgKgSCA1sqEEoLpDTCAOssAKCRGxUACIJARWAAICwcAwRICViwQJMUb5ACMEKAUSoVqIAAAAA.YAAAAAAAAAAA"
+          }
+        ]
+      },
+      "id": "1b9d2d3b-484c-4654-8da5-a73497b2a206"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "presence": "div#buttons"
+      },
+      "domain": "trendings.es",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPhJZsAPhJZsAAHABBENClCsAP_AAH_AAAiQJFNf_X__b2_r-_5_f_t0eY1P9_7__-0zjhfdl-8N3f_X_L8X52M7vF36tq4KuR4ku3LBIUdlHOHcTUmw6okVryPsbk2cr7NKJ7PEmnMbOydYGH9_n1_z-ZKY7___f_7z_v-v___3____7-3f3__5___-__e_V__9zfn9_____9vP___9v-_9__________3_7997BIQAkw1biALsSxwJtowigRAjCsJDqBQAUUAwtEBhA6uCnZXAT6wgQAIBQBGBECHAFGDAIAAAIAkIiAkCPBAIACIBAACABUIhAARsAgoALAwCAAUA0LFGKAIQJCDIgIilMCAiRIKCeyoQSg_0NMIQ6ywAoNH_FQgIlACFYEQkLByHBEgJeLJAsxRvkAIwQoBRKhWoAAAA.f_gAD_gAAAAA"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPhJZsAPhJZsAAHABBENClCgAAAAAH_AAAiQAAASEAJMNW4gC7EscCbaMIoEQIwrCQ6gUAFFAMLRAYQOrgp2VwE-sIEACAUARgRAhwBRgwCAAACAJCIgJAjwQCAAiAQAAgAVCIQAEbAIKACwMAgAFANCxRigCECQgyICIpTAgIkSCgnsqEEoP9DTCEOssAKDR_xUICJQAhWBEJCwchwRICXiyQLMUb5ACMEKAUSoVqAA.YAAAD_gAAAAA"
+          }
+        ]
+      },
+      "id": "13dff385-bb91-414f-8fa3-88ae99621aba"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "optOut": "button#didomi-notice-disagree-button",
+        "presence": "div#buttons"
+      },
+      "domain": "markiza.sk",
+      "cookies": {},
+      "id": "d34353ab-218a-49f7-830e-d14dbd9f98eb"
+    },
+    {
+      "click": {
+        "optIn": "input.btn-secondary",
+        "presence": "div.stampenCookieContainer"
+      },
+      "domain": "gp.se",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "_pctx",
+            "value": "%7Bu%7DN4IgDghg5gpgagSxgdwJIBMQC4QBsCcUArgGwBGA1jALYBuAXkQCwBMAdgPYgA0IRAzjABO-bGyK5cvAcIDKAFwjyB2EBE5seIfgnkwMqgIyGAzCfyGAHExMBWQwAYbTSw9sB2EAF8gA"
+          }
+        ]
+      },
+      "id": "e4e59ff1-b18c-453b-a4e0-6c0ec4008d81"
+    },
+    {
+      "click": {
+        "optIn": "button.mat-button-base",
+        "presence": "section#cookie-banner"
+      },
+      "domain": "migros.ch",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "cookie-banner-acceptance-state",
+            "value": "true"
+          }
+        ]
+      },
+      "id": "cd670e2a-b764-4722-8ff2-a136350a60d8"
+    },
+    {
+      "click": {
+        "optIn": "button#onetrust-accept-btn-handler",
+        "optOut": "button#onetrust-reject-all-handler",
+        "presence": "div#onetrust-consent-sdk"
+      },
+      "domain": "kuleuven.be",
+      "cookies": {},
+      "id": "724b4210-1734-404e-bf10-9af198958ef4"
+    },
+    {
+      "click": {
+        "optIn": "a#wt-cli-accept-all-btn",
+        "presence": "div.cli-bar-container"
+      },
+      "domain": "katalozi.net",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "viewed_cookie_policy",
+            "value": "yes"
+          },
+          {
+            "name": "CookieLawInfoConsent",
+            "value": "eyJuZWNlc3NhcnkiOnRydWUsImFuYWx5dGljcyI6dHJ1ZSwiYWR2ZXJ0aXNlbWVudCI6dHJ1ZSwib3RoZXJzIjp0cnVlLCJwZXJmb3JtYW5jZSI6dHJ1ZX0="
+          }
+        ]
+      },
+      "id": "caddc16b-c8ad-404a-bd29-6383977695cb"
+    },
+    {
+      "click": {
+        "optIn": "button.rounded-button--tertiary",
+        "presence": "div.legal-consent"
+      },
+      "domain": "mall.cz",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "mal_consent_gdpr_remarketing",
+            "value": "t"
+          },
+          {
+            "name": "mal_consent_gdpr_personalization",
+            "value": "t"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "mal_consent_gdpr_remarketing",
+            "value": "f"
+          },
+          {
+            "name": "mal_consent_gdpr_personalization",
+            "value": "1"
+          }
+        ]
+      },
+      "id": "6bc9ceec-b225-4284-b924-589c3ff4f249"
+    },
+    {
+      "click": {
+        "optIn": "a.wscrOk",
+        "optOut": "a.wscrOk2",
+        "presence": "div.wscrBannerContent"
+      },
+      "domain": "nordea.fi",
+      "cookies": {},
+      "id": "cf282f72-5333-48a8-9097-cbc89ea26634"
+    },
+    {
+      "click": {
+        "optIn": "button.btn-primary",
+        "presence": "div.alert-secondary"
+      },
+      "domain": "bakecaincontrii.com",
+      "cookies": {
+        "optOut": [
+          {
+            "name": "privacy_cookie",
+            "value": "1"
+          }
+        ]
+      },
+      "id": "a8984148-8c62-4dd5-8350-4e0da48f1829"
+    },
+    {
+      "click": {
+        "optIn": "button#grantPermissionButton",
+        "presence": "div#cookie-bar"
+      },
+      "domain": "postnl.nl",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "_fbp",
+            "value": "fb.1.1666257920980.1495539528"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "CookiePermissionInfo",
+            "value": "%7B%22LastModifiedDate%22%3A%22%5C%2FDate(1666257491849)%5C%2F%22%2C%22ExpirationDate%22%3A%22%5C%2FDate(1697793491849)%5C%2F%22%2C%22Allow%22%3Afalse%2C%22CategoryPermission%22%3A%5B%7B%22Category%22%3A%22Cat.8%22%2C%22Permission%22%3Atrue%7D%2C%7B%22Category%22%3A%22Cat.9%22%2C%22Permission%22%3Atrue%7D%2C%7B%22Category%22%3A%22Cat.10%22%2C%22Permission%22%3Afalse%7D%2C%7B%22Category%22%3A%22Cat.11%22%2C%22Permission%22%3Afalse%7D%2C%7B%22Category%22%3A%22Cat.12%22%2C%22Permission%22%3Afalse%7D%5D%7D"
+          }
+        ]
+      },
+      "id": "e4a9e084-a37e-4f10-969c-c872f578dd15"
+    },
+    {
+      "click": {
+        "optIn": "button.css-47sehv",
+        "presence": "div.qc-cmp2-summary-buttons"
+      },
+      "domain": "evz.ro",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "__gfp_64b",
+            "value": "nXC7yXo8aJ2dRZK6WNanPiTothNgalkp.W2jhtT2uzb.o7|1666265842"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "addtl_consent",
+            "value": "1~"
+          },
+          {
+            "name": "euconsent-v2",
+            "value": "CPhJZsAPhJZsAAKAsBROClCgAAAAAH_AACJwAAASIAJMNW4gC7MscGbQMIoEQIwrCQqgUAEFAMLRAYAODgp2VgE-sIEACAUARgRAhwBRgQCAAASAJCIAJAiwQAAAiAQAAgARCIQAMDAILACwMAgABANAxRCgAECQgyICIpTAgKgSCA1sqEEoLpDTCAOssAKCRGxUACIJARWAAICwcAwRICViwQJMUb5ACMEKAUSoVqIAAAAA.YAAAAAAAAAAA"
+          }
+        ]
+      },
+      "id": "ad724f2b-3721-4b6a-ac55-a52f14e26727"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "presence": "div#didomi-popup"
+      },
+      "domain": "elperiodico.com",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "cto_bundle",
+            "value": "MQvei19neFI5aFp1a0lwaktzV3JOMG96R2VkSFh0NjI1VnJsRVF0TDRhd0NmNUQ5NTdXcTFuTGVBJTJGZlFRbjhwJTJGaGk2JTJCRWpObGZ5WlRFMFhUTHlteE9TeXVGOEdubTZGSTZqMjhSWkpSRnZPZmpYZXNldW10TWJob2pXV2NYTlJoVnhDJTJGcVQwQTIlMkZ1NmE3RXhLaEEyRTFxMmtRJTNEJTNE"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "_pbjs_userid_consent_data",
+            "value": "1293559250372564"
+          },
+          {
+            "name": "euconsent-v2",
+            "value": "CPhJZsAPhJZsAAHABBENClCgAAAAAAAAAAiQAAAAAAEhoAMAAQSKFQAYAAgkUEgAwABBIoRABgACCRQyADAAEEih0AGAAIJFEIAMAAQSKJQAYAAgkUUgAwABBIoA.YAAAAAAAAAAA"
+          }
+        ]
+      },
+      "id": "8c5d8c15-fcda-405d-a897-76e0fb014b10"
+    },
+    {
+      "click": {
+        "optIn": "button.dl_cookieBanner--buttonAll",
+        "optOut": "button.dl_cookieBanner--buttonSelected",
+        "presence": "div.dl_cookieBanner"
+      },
+      "domain": "deepl.com",
+      "cookies": {},
+      "id": "e3968548-ebca-4d6b-b8cf-5707e90fb612"
+    },
+    {
+      "click": {
+        "optIn": "button#onetrust-accept-btn-handler",
+        "presence": "div#onetrust-consent-sdk"
+      },
+      "domain": "tripadvisor.co.uk",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "eupubconsent-v2",
+            "value": "CPhI_UgPhI_UgAcABBENClCsAP_AAH_AACiQJFNf_X__b2_r-_5_f_t0eY1P9_7__-0zjhfdl-8N3f_X_L8X52M7vF36tq4KuR4ku3LBIUdlHOHcTUmw6okVryPsbk2cr7NKJ7PEmnMbOydYGH9_n1_z-ZKY7___f_7z_v-v___3____7-3f3__5___-__e_V__9zfn9_____9vP___9v-_9__________3_7997BIgAkw1biALsyxwZtowigRAjCsJDqBQAUUAwtEBhA6uCnZXAT6wgQAIBQBOBECHAFGDAIAABIAkIiAkCPBAIACIBAACABUIhAAxsAgsALAwCAAUA0LFGKAIQJCDIgIilMCAqRIKDeyoQSg_0NMIQ6ywAoNH_FQgI1kDFYEQkLByHBEgJeLJA8xRvkAIwQoBRKhWogAAA.f_gAD_gAAAAA"
+          },
+          {
+            "name": "_pbjs_userid_consent_data",
+            "value": "906035206529064"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "eupubconsent-v2",
+            "value": "CPhI_UgPhI_UgAcABBENClCgAAAAAAAAACiQAAAAAAAA.YAAAAAAAAAAA"
+          },
+          {
+            "name": "OTAdditionalConsentString",
+            "value": "1~"
+          }
+        ]
+      },
+      "id": "76a588e7-a8b0-4d2a-839d-239f80cb5802"
+    },
+    {
+      "click": {
+        "optIn": "button.js_cookieBannerPermissionButton",
+        "optOut": "span.js_cookieBannerProhibitionButton",
+        "presence": "div.cookieBanner__container"
+      },
+      "domain": "otto.de",
+      "cookies": {},
+      "id": "c9adac7f-74db-4eab-9b97-114ff5954226"
+    },
+    {
+      "click": {
+        "optIn": "button#uc-btn-accept-banner",
+        "optOut": "button#uc-btn-deny-banner",
+        "presence": "div.uc-banner-content"
+      },
+      "domain": "zalando.be",
+      "cookies": {},
+      "id": "6a6864e3-dbfb-4fb7-b265-17a12231a11c"
+    },
+    {
+      "click": {
+        "optIn": "a#accept-button",
+        "optOut": "a#CybotCookiebotDialogBodyButtonDecline",
+        "presence": "div#c-right"
+      },
+      "domain": "yettel.bg",
+      "cookies": {},
+      "id": "4ec170c6-933c-4612-9907-80bc8ef6039c"
+    },
+    {
+      "click": {
+        "optIn": "button.pr-f3iejo",
+        "optOut": "button.pr-1wrnevh",
+        "presence": "div.VkNOzuzy1E"
+      },
+      "domain": "pricerunner.dk",
+      "cookies": {},
+      "id": "be039e17-f095-46f4-a809-c00699799db8"
+    },
+    {
+      "click": {
+        "optIn": "button.css-1lgi3ta",
+        "presence": "div.qc-cmp2-summary-buttons"
+      },
+      "domain": "makeleio.gr",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPhJZsAPhJZsAAKAsAELClCsAP_AAH_AAAyIJFNd_H__bW9r-f5_aft0eY1P9_r37uQzDhfNk-8F3L_W_LwX52E7NF36tq4KmR4ku1LBIUNlHMHUDUmwaokVryHsak2cpzNKJ7BEknMZOydYGF9vmxtj-QKY7_5_d3bx2D-t_9v239z3z81Xn3d53-_03LCdV5_9Dfn9fR_bc9KPt_58v8v8_____3_e__3_7997BIgAkw1biALsyxwZtAwigRAjCsJCqBQAQUAwtEBgA4OCnZWAT6wgQAIBQBGBECHAFGBAIAABIAkIgAkCLBAAACIBAACABEIhAAwMAgsALAwCAAEA0DFEKAAQJCDIgIilMCAqBIIDWyoQSgukNMIA6ywAoJEbFQAIgkBFYAAgLBwDBEgJWLBAkxRvkAIwQoBRKhWogAAA.f_gAAAAAAAAA"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPhJZsAPhJZsAAKAsAELClCgAAAAAH_AAAyIAAASIAJMNW4gC7MscGbQMIoEQIwrCQqgUAEFAMLRAYAODgp2VgE-sIEACAUARgRAhwBRgQCAAASAJCIAJAiwQAAAiAQAAgARCIQAMDAILACwMAgABANAxRCgAECQgyICIpTAgKgSCA1sqEEoLpDTCAOssAKCRGxUACIJARWAAICwcAwRICViwQJMUb5ACMEKAUSoVqIAAAAA.YAAAAAAAAAAA"
+          },
+          {
+            "name": "addtl_consent",
+            "value": "1~"
+          }
+        ]
+      },
+      "id": "d5bfd040-a445-44f4-9773-fb7cf19cff79"
+    },
+    {
+      "click": {
+        "optIn": "button#didomi-notice-agree-button",
+        "presence": "div#didomi-host"
+      },
+      "domain": "dumpert.nl",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "cto_bundle",
+            "value": "fTQ2al9ubUczRmVXOU1YQ1NIJTJCYjdWbVpUYkhDaDdxMTlhaFM2aWE1eEtNWHRwRXdobE1rQVNLV2olMkJib2lDRVVNMEpzenVXODRiTFUzZ3daYlY5YW9POU85NzhpNE9LcVNEbGJsJTJCRXhoeSUyRnMzWFpoOCUyQkdHclphamhZMSUyQlFySTNhTzZhJTJGSWdTaHBSd0FhdExOMHJ4aFZFNXFCQSUzRCUzRA"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPhJZsAPhJZsAAHABBENClCgAAAAAAAAAAAAAAAAAABBoAMAAQSKEQAYAAgkUAAA.YAAAAAAAAAAA"
+          }
+        ]
+      },
+      "id": "1f22604b-d1f0-4e4a-a2ed-699abd3e61e7"
+    },
+    {
+      "click": {
+        "optIn": "div.tvp-covl__ab",
+        "presence": "div#ip"
+      },
+      "domain": "tvp.pl",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "TVPtcs2",
+            "value": "CPhOZ67PhOZ67FfACAENCmCsAP_AAH_AAB5YJFNd_H__bW9r-f5_aft0eY1P9_r37uQzDhfNk-8F3L_W_LwX52E7NF36tq4KmR4ku1LBIUNlHMHUDUmwaokVryHsak2cpzNKJ7BEknMZOydYGF9vmxtj-QKY7_5_d3bx2D-t_9v239z3z81Xn3d53-_03LCdV5_9Dfn9fR_bc9KPt_58v8v8_____3_e__3_7997BIQAkw1biALsSxwJtAwigRAjCsJCqBQAQUAwtEBgA4OCnZWAT6wgQAIBQBGBECHAFGBAIAAAIAkIgAkCLBAAACIBAACABEIhAAQMAgoALAwCAAEA0DFEKAAQJCDIgIilMCAiBIICWyoQSgukNMIA6ywAoJEbFQAIgAAFYAAgLBwDBEgJWLBAkxRvkAIwQoBRKhWoAAAA.f_gAAAAABX_gAAAA"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "TVPtcs2ver",
+            "value": "166"
+          }
+        ]
+      },
+      "id": "fb333123-4f00-4b45-acf9-21cb038c76ba"
+    },
+    {
+      "click": {
+        "optIn": "button.css-1g5s5vy",
+        "presence": "div#qc-cmp2-ui"
+      },
+      "domain": "meo.pt",
+      "cookies": {
+        "optIn": [
+          {
+            "name": "_gcl_au",
+            "value": "1.1.728794945.1666355472"
+          }
+        ]
+      },
+      "id": "992a91e5-9d29-411a-a8e6-e689fb75c2b7"
     }
   ]
 }


### PR DESCRIPTION
Adding 294 new rules for:
aktualne.cz, sport24.gr, corriere.it, tv2.no, elmundo.es, censor.net, olx.bg, dnevnik.hr, google.cz, olx.pt, rte.ie, b92.net, pravda.sk, blocket.se, heute.at, sportal.bg, google.hr, google.com.ua, fakti.bg, njuskalo.hr, google.no, plovdiv24.bg, gsis.gr, vodafone.com, cas.sk, nova.bg, nova.cz, op.fi, marktplaats.nl, sport.ro, azet.sk, mundodeportivo.com, dn.se, bluewin.ch, n-tv.de, bergfex.at, dnes.bg, blesk.cz, mtvuutiset.fi, ouest-france.fr, mediaset.it, buienradar.nl, tvn24.pl, google.ru, oe24.at, rtbf.be, dnevno.hr, bt.dk, veikkaus.fi, 3bmeteo.com, irishtimes.com, libertatea.ro, 20minutos.es, sudinfo.be, zamunda.net, centrum.cz, gazeta.pl, hotnews.ro, elpais.com, sinoptik.bg, bazos.cz, seiska.fi, lemonde.fr, gazzetta.it, sport.es, 2dehands.be, novilist.hr, iprima.cz, subito.it, irishmirror.ie, funda.nl, businessinsider.com.pl, adevarul.ro, heureka.sk, elespanol.com, watson.ch, rightmove.co.uk, theweathernetwork.com, standaard.be, heureka.cz, dmi.dk, lequipe.fr, jofogas.hu, e24.no, mediaexpert.pl, novosti.rs, alza.sk, ricardo.ch, viaplay.dk, meteofrance.com, aib.ie, otomoto.pl, mondo.rs, abc.es, cbc.ca, weather.com, bazar.bg, denik.cz, etuovi.com, newsit.gr, startsiden.no, sport.pl, noticiasaominuto.com, telegraf.rs, profesia.sk, flashback.org, wetter.com, gva.be, ampparit.com, bfmtv.com, meteo.gr, videa.hu, abcnyheter.no, filmweb.pl, expresso.pt, publi24.ro, hitta.se, belgium.be, novini.bg, csfd.cz, hbomax.com, sport-fm.gr, espreso.co.rs, lavanguardia.com, svd.se, mirror.co.uk, espn.com, dhl.de, alza.cz, disneyplus.com, suomi24.fi, car.gr, femina.hu, poste.it, rtlnieuws.nl, playtech.ro, idealista.com, tagesanzeiger.ch, focus.de, kauppalehti.fi, francetvinfo.fr, news247.gr, libero.it, rip.ie, viaplay.no, medonet.pl, idealista.pt, modrykonik.sk, eltiempo.es, di.se, sbb.ch, google.com.br, alo.bg, story.hr, borsonline.hu, sky.it, rabobank.nl, fakt.pl, stiripesurse.ro, informer.rs, atg.se, eluniversal.com.mx, wetteronline.de, meteo.be, in-pocasi.cz, nordea.com, athensmagazine.gr, thesun.ie, voetbalzone.nl, globo.com, stirileprotv.ro, sberbank.ru, danas.rs, hola.com, thesun.co.uk, lesoir.be, rtl.hr, e-boks.com, free.fr, voetbalprimeur.nl, dnb.no, ziare.com, eldiario.es, 1177.se, nv.ua, express.co.uk, samsung.com, oikotie.fi, pronews.gr, nemzetisport.hu, ebay.it, swisscom.ch, vesti.bg, gloria.hr, politiken.dk, nettiauto.com, actu.fr, sportdog.gr, emag.hu, ilgiornale.it, meczyki.pl, worten.pt, dobrenoviny.sk, huffingtonpost.es, tradera.com, rts.ch, meinbezirk.at, rtl.be, dnevnik.bg, linker.hr, sfr.fr, online-filmek.me, irishexaminer.com, orange.ro, alo.rs, larazon.es, ikea.com, td.com, amazon.fr, mobile.bg, berlingske.dk, 20minutes.fr, tripadvisor.it, thejournal.ie, observador.pt, aemet.es, newsnow.co.uk, supersport.hr, hn.cz, yousee.dk, napi.hu, amazon.nl, plejada.pl, superbet.ro, mozzartsport.com, gong.bg, extra.cz, telsu.fi, gossip-tv.gr, liberoquotidiano.it, vi.nl, sol.no, g4media.ro, okdiario.com, dhnet.be, news.bg, zougla.gr, calciomercato.com, telenor.no, wyborcza.pl, 2gis.ru, ica.se, walmart.ca, nachrichten.at, roblox.com, leparisien.fr, newsbeast.gr, giallozafferano.it, pomponik.pl, lecturas.com, avanza.se, post.ch, news.sky.com, accuweather.com, tt.com, klik.hr, doctolib.fr, hasznaltauto.hu, three.ie, flashscore.pl, zerozero.pt, cancan.ro, trendings.es, markiza.sk, gp.se, migros.ch, kuleuven.be, katalozi.net, mall.cz, nordea.fi, bakecaincontrii.com, postnl.nl, evz.ro,elperiodico.com, deepl.com, tripadvisor.co.uk, otto.de, zalando.be, yettel.bg, pricerunner.dk, makeleio.gr, dumpert.nl, tvp.pl, meo.pt