### PR TITLE
Update gravatar presence selector

### DIFF
--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -22,7 +22,7 @@
     {
       "click": {
         "optIn": ".a8c-cookie-banner-accept-all-button",
-        "presence": "div.a8c-cookie-banner"
+        "presence": ".a8c-cookie-banner"
       },
       "domain": "gravatar.com",
       "cookies": {},


### PR DESCRIPTION
I've retained the element dot selector format here from the previous rule, although just using `.a8c-cookie-banner` might be more robust to future changes.

Fixes #19.