### PR TITLE
Fix dhl.de rule causing a reload loop.

### DIFF
--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -4157,17 +4157,9 @@
       "click": {
         "optIn": "button#accept-recommended-btn-handler",
         "optOut": "button#confirm-choices-handler",
-        "presence": "div#onetrust-consent-sdk"
+        "presence": "div#onetrust-pc-sdk"
       },
       "domain": "dhl.de",
-      "cookies": {
-        "optIn": [
-          {
-            "name": "s_cc",
-            "value": "true"
-          }
-        ]
-      },
       "id": "6dddbd1c-6c99-4085-abf7-8aa15d230701"
     },
     {


### PR DESCRIPTION
#onetrust-consent-sdk is always visible on dhl.de causing is to click on every page load which triggers a reload since we handled the banner.
Switching detection to div#onetrust-pc-sdk is a tradeoff.  It fixes the reload issue but introduces another issue where we fail to properly hide the banner while handling it.
The proper fix for this would be to hide both children of #onetrust-consent-sdk which we currently lack the capability for in our clicking code.