### PR TITLE
Fix the rule for twitter.com

### DIFF
--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -297,13 +297,21 @@
       "id": "caf8d44d-af29-47a9-aa66-ec4041655d33"
     },
     {
-      "click": {
-        "optIn": "div#layers div[role]",
-        "optOut": "div#layers div[role] + div[role]",
-        "presence": "div#layers > div > div > div > div > div"
-      },
       "domain": "twitter.com",
-      "cookies": {},
+      "cookies": {
+        "optOut": [
+          {
+            "name": "d_prefs",
+            "value": "MjoxLGNvbnNlbnRfdmVyc2lvbjoyLHRleHRfdmVyc2lvbjoxMDAw"
+          }
+        ],
+        "optIn": [
+          {
+            "name": "d_prefs",
+            "value": "MToxLGNvbnNlbnRfdmVyc2lvbjoyLHRleHRfdmVyc2lvbjoxMDAw"
+          }
+        ]
+      },
       "id": "05b3b417-c4c7-4ed0-a3cf-43053e8b33ab"
     },
     {


### PR DESCRIPTION
The click rule was too generic causing false-positives.
The updated rule relies on cookie injection rather than clicking. It sets the d_prefs cookie which is a base64 encoded version of the cookie banner preferences.
Fixes #68