### PR TITLE
Updated rules for unscrollable sites

### DIFF
--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -959,9 +959,7 @@
       "cookies": {},
       "id": "af4c5b38-d210-472b-9a07-21cbe53c85ab",
       "domains": [
-        "marca.com",
         "24sata.hr",
-        "elmundo.es",
         "lidovky.cz",
         "jutarnji.hr",
         "orange.fr",
@@ -1866,22 +1864,6 @@
     {
       "click": {
         "optIn": "button#didomi-notice-agree-button",
-        "presence": "div#didomi-host"
-      },
-      "cookies": {
-        "optIn": [
-          {
-            "name": "didomi_token",
-            "value": "eyJ1c2VyX2lkIjoiMTgzYzExNTEtYzFmNS02NGIxLTg3ZjEtZTA0ZWViMjBjZjdjIiwiY3JlYXRlZCI6IjIwMjItMTAtMTBUMDg6NDg6NTcuNDI5WiIsInVwZGF0ZWQiOiIyMDIyLTEwLTEwVDA4OjQ4OjU3LjQyOVoiLCJ2ZW5kb3JzIjp7ImVuYWJsZWQiOlsiZ29vZ2xlIiwiYzp5YWhvby1hZC1leGNoYW5nZSIsImM6eWFob28tYW5hbHl0aWNzIiwiYzp5YWhvby1hZC1tYW5hZ2VyLXBsdXMiLCJjOnBlcmZvcm1pb2N6IiwiYzpnb29nbGVhbmEtNFRYbkppZ1IiLCJjOmZ0dnByaW1hLUdNRTNLRkdSIl19LCJwdXJwb3NlcyI6eyJlbmFibGVkIjpbImZ0di1wcmltYSJdfSwidmVyc2lvbiI6MiwiYWMiOiJDWG1BRUFGa0V2SUEuQUFBQSJ9"
-          }
-        ]
-      },
-      "id": "bd685e6d-3260-4529-a4e6-acb116325ad4",
-      "domains": ["iprima.cz"]
-    },
-    {
-      "click": {
-        "optIn": "button#didomi-notice-agree-button",
         "presence": "div#buttons"
       },
       "cookies": {
@@ -2659,24 +2641,6 @@
       },
       "id": "1b1bdbb4-089c-45dc-9d42-e87a1fa85882",
       "domains": ["news247.gr"]
-    },
-    {
-      "click": {
-        "optIn": "button.iubenda-cs-accept-btn",
-        "optOut": "button.iubenda-cs-reject-btn",
-        "presence": "div#iubenda-cs-banner"
-      },
-      "cookies": {
-        "optIn": [
-          {
-            "name": "cto_bundle",
-            "value": "5jZ-f19NNTIlMkJUWUJwNDBlYk9hcmJTMnJHT1BoeHF2dXFkUkZJWmtpOGJaQTZaWHBKR1dvazhjREx0VzZCNzVFUWFQSVdHTndiJTJGJTJGdDFFOHFBZk9yalhMSXM1QlZ3OXhqM1ZhSVclMkZEelkwVjExQ0t3WlZYSmJ1JTJGSmx2NlB4QUpmd0xWcDk"
-          }
-        ],
-        "optOut": [{ "name": "HPtestAB", "value": "4" }]
-      },
-      "id": "4e4fa6fd-4412-431a-8e1b-b7266920436a",
-      "domains": ["libero.it"]
     },
     {
       "click": {
@@ -6040,6 +6004,18 @@
       },
       "id": "24fdb694-9d8f-4049-a2f1-583465e711a5",
       "domains": ["autodesk.com"]
+    },
+    {
+      "cookies": {
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CPkVv0APkVv0AAHABBENCuCgAAAAAAAAAAAAAAAAAAEEoAMAAQSXDQAYAAgkuKgAwABBJcpABgACCS46ADAAEElyEAGAAIJLhIAMAAQSXGQAYAAgkuAA.YAAAAAAAAAAA"
+          }
+        ]
+      },
+      "id": "77885432-826b-4d03-bb3d-dfdd36015a82",
+      "domains": ["iprima.cz", "elmundo.es", "marca.com"]
     }
   ]
 }


### PR DESCRIPTION
Removed click rules, added cookie rules and merged iprima.cz, elmundo.es, marca.com into rule 77885432-826b-4d03-bb3d-dfdd36015a82. Removed rule for libero.it for further investigation. For now, the rule cannot be fixed using cookies or CSS selectors. Fixed issues #79, #81, #83.