### PR TITLE
Merge rules for sites using Didomi CMP without cookie rules

### DIFF
--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -874,7 +874,30 @@
         "20minutes.fr",
         "actu.fr",
         "hbvl.be",
-        "naszemiasto.pl"
+        "naszemiasto.pl",
+        "leboncoin.fr",
+        "rtbf.be",
+        "20minutos.es",
+        "sudinfo.be",
+        "elpais.com",
+        "sinoptik.bg",
+        "subito.it",
+        "lequipe.fr",
+        "abc.es",
+        "gva.be",
+        "eltiempo.es",
+        "eldiario.es",
+        "larazon.es",
+        "extra.cz",
+        "leparisien.fr",
+        "ladepeche.fr",
+        "marmiton.org",
+        "poslovni.hr",
+        "reverso.net",
+        "softonic.com",
+        "sydsvenskan.se",
+        "telecinco.es",
+        "giphy.com"
       ]
     },
     {
@@ -1015,22 +1038,6 @@
       },
       "id": "7850dc20-f121-417b-9eb0-d91a0a8d6a8c",
       "domains": ["blitz.bg"]
-    },
-    {
-      "click": {
-        "optIn": "button#didomi-notice-agree-button",
-        "presence": "div#buttons"
-      },
-      "cookies": {
-        "optOut": [
-          {
-            "name": "atauthority",
-            "value": "%7B%22name%22%3A%22atauthority%22%2C%22val%22%3A%7B%22authority_name%22%3A%22cnil%22%2C%22visitor_mode%22%3A%22exempt%22%7D%2C%22options%22%3A%7B%22end%22%3A%222023-11-05T09%3A17%3A06.829Z%22%2C%22path%22%3A%22%2F%22%7D%7D"
-          }
-        ]
-      },
-      "id": "ca9fef29-efe4-4f88-8b18-6c8d87414ffe",
-      "domains": ["leboncoin.fr"]
     },
     {
       "click": {
@@ -1300,22 +1307,6 @@
     },
     {
       "click": {
-        "optIn": "button#didomi-notice-agree-button",
-        "presence": "div#didomi-popup"
-      },
-      "cookies": {
-        "optOut": [
-          {
-            "name": "didomi_token",
-            "value": "eyJ1c2VyX2lkIjoiMTgzYjJkZWEtMzZiNC02YzExLThhMmItNzRhOWY0YzMzZjQwIiwiY3JlYXRlZCI6IjIwMjItMTAtMDdUMTQ6MzQ6NTEuMTQ3WiIsInVwZGF0ZWQiOiIyMDIyLTEwLTA3VDE0OjM0OjUxLjE0N1oiLCJ2ZW5kb3JzIjp7ImRpc2FibGVkIjpbImdvb2dsZSIsImM6Z29vZ2xlYW5hLTRUWG5KaWdSIl19LCJwdXJwb3NlcyI6eyJkaXNhYmxlZCI6WyJkZXZpY2VfY2hhcmFjdGVyaXN0aWNzIiwiZ2VvbG9jYXRpb25fZGF0YSJdfSwidmVyc2lvbiI6Mn0="
-          }
-        ]
-      },
-      "id": "8362bf12-5c9e-4028-8077-b7194b7aa020",
-      "domains": ["rtbf.be"]
-    },
-    {
-      "click": {
         "optIn": "button.fc-cta-consent",
         "presence": "div.fc-footer-buttons"
       },
@@ -1368,73 +1359,12 @@
       "domains": ["3bmeteo.com"]
     },
     {
-      "click": {
-        "optIn": "button#didomi-notice-agree-button",
-        "presence": "div#didomi-host"
-      },
-      "cookies": {
-        "optOut": [
-          {
-            "name": "didomi_token",
-            "value": "eyJ1c2VyX2lkIjoiMTgzYzBlY2ItYmExMS02MDQ2LTgwZDMtYmUyNjcyOTZhOTg5IiwiY3JlYXRlZCI6IjIwMjItMTAtMTBUMDg6MDU6MTAuNzIxWiIsInVwZGF0ZWQiOiIyMDIyLTEwLTEwVDA4OjA1OjEwLjcyMVoiLCJ2ZW5kb3JzIjp7ImRpc2FibGVkIjpbImdvb2dsZSIsImM6dmVuZG9yLXByb21ldGVvIiwiYzpjaXRpc2VydmktWXRnR0RuOUgiLCJjOnZlbmRvci1kb2d0cmFjayJdfSwicHVycG9zZXMiOnsiZGlzYWJsZWQiOlsiZGV2aWNlX2NoYXJhY3RlcmlzdGljcyIsImdlb2xvY2F0aW9uX2RhdGEiXX0sInZlbmRvcnNfbGkiOnsiZGlzYWJsZWQiOlsiZ29vZ2xlIl19LCJ2ZXJzaW9uIjoyLCJhYyI6IkFBQUEuQUFBQSJ9"
-          }
-        ]
-      },
-      "id": "bb2b02a7-2627-4c94-a329-5013551aedc0",
-      "domains": ["20minutos.es"]
-    },
-    {
-      "click": {
-        "optIn": "button#didomi-notice-agree-button",
-        "presence": "div#buttons"
-      },
-      "cookies": {
-        "optOut": [
-          {
-            "name": "didomi_token",
-            "value": "eyJ1c2VyX2lkIjoiMTgzYzBlZWUtMjEwNi02N2Q5LTkzZjYtNWNlNWFlYWY5YzM3IiwiY3JlYXRlZCI6IjIwMjItMTAtMTBUMDg6MDc6MzAuNDkwWiIsInVwZGF0ZWQiOiIyMDIyLTEwLTEwVDA4OjA3OjMwLjQ5MFoiLCJ2ZW5kb3JzIjp7ImRpc2FibGVkIjpbInR3aXR0ZXIiLCJnb29nbGUiLCJjOnF1YWxpZmlvLTlKUWpKSmhCIiwiYzp5b3V0dWJlIiwiYzpob3RqYXIiLCJjOmluc3RhZ3JhbSIsImM6Y2hhcnRiZWF0IiwiYzpncmFwZXNob3QiLCJjOndpc2Vwb3BzIiwiYzp2aWRlb3BsYXphIiwiYzpoZWxwaGVyby05VEJmWHR5dCIsImM6c2VsbGlnZW50LUdnd0RXZG5oIiwiYzpvbmVzaWduYWwtcVYyQ0VwV2oiLCJjOmdvb2dsZWFuYS00VFhuSmlnUiIsImM6cWlvdGEtaFVZSEt3dzIiLCJjOmFpcnNoaXAiLCJjOnBpYW5vIl19LCJwdXJwb3NlcyI6eyJkaXNhYmxlZCI6WyJkZXZpY2VfY2hhcmFjdGVyaXN0aWNzIiwiZ2VvbG9jYXRpb25fZGF0YSIsImdlb19tYXJrZXRpbmdfc3R1ZGllcyIsImdlb19hZHMiLCJjb29raWVzZm8tUUhqV2hLMkciXX0sInZlcnNpb24iOjIsImFjIjoiQUFBQS5BQUFBIn0="
-          }
-        ]
-      },
-      "id": "7aeca59f-133a-4d42-bd80-fdddfff7bc74",
-      "domains": ["sudinfo.be"]
-    },
-    {
       "click": { "optIn": "button", "presence": "div.gdprcookie" },
       "cookies": {
         "optOut": [{ "name": "cookieControlPrefs", "value": "[\"essential\"]" }]
       },
       "id": "03f54762-dc2a-4cf9-bf1b-412a68dbf0db",
       "domains": ["zamunda.net"]
-    },
-    {
-      "click": {
-        "optIn": "button#didomi-notice-agree-button",
-        "presence": "div#buttons"
-      },
-      "cookies": {
-        "optOut": [
-          {
-            "name": "didomi_token",
-            "value": "eyJ1c2VyX2lkIjoiMTgzYzBmYjAtMDQ5Mi02ZDhjLTg0NjgtMzRiMTU4ZDRiZTBjIiwiY3JlYXRlZCI6IjIwMjItMTAtMTBUMDg6MjA6MzkuNDk0WiIsInVwZGF0ZWQiOiIyMDIyLTEwLTEwVDA4OjIwOjM5LjQ5NFoiLCJ2ZW5kb3JzIjp7ImRpc2FibGVkIjpbImdvb2dsZSIsInR3aXR0ZXIiXX0sInB1cnBvc2VzIjp7ImRpc2FibGVkIjpbImRldmljZV9jaGFyYWN0ZXJpc3RpY3MiLCJnZW9sb2NhdGlvbl9kYXRhIiwiZGF0YV9zaGFyaW5nIl19LCJ2ZXJzaW9uIjoyLCJhYyI6IkFBQUEuQUFBQSJ9"
-          }
-        ]
-      },
-      "id": "ed9b78fc-c23e-494b-9d2a-c837abf424d0",
-      "domains": ["elpais.com"]
-    },
-    {
-      "click": {
-        "optIn": "button#didomi-notice-agree-button",
-        "presence": "div#buttons"
-      },
-      "cookies": {
-        "optOut": [
-          { "name": "_pbjs_userid_consent_data", "value": "689651363488201" }
-        ]
-      },
-      "id": "cdfbb69b-a204-43ae-b9a7-0feb54f9106b",
-      "domains": ["sinoptik.bg"]
     },
     {
       "click": {
@@ -1542,23 +1472,6 @@
     },
     {
       "click": {
-        "optIn": "button#didomi-notice-agree-button",
-        "presence": "div#buttons"
-      },
-      "cookies": {
-        "optIn": [],
-        "optOut": [
-          {
-            "name": "euconsent-v2",
-            "value": "CPgprWUPgprWUAKAmBENCkCgAAAAAH_AAAwIAAASIAJMNW4gC7MscGbQMIoEQIwrCQqgUAEFAMLRAYAODgp2VgE-sIEACAUARgRAhwBRgQCAAASAJCIAJAiwQAAAiAQAAgARCIQAMDAILACwMAgABANAxRCgAECQgyICApTAgKgSCA1sqEEoLpDTCAOssAKCRGxUACIJARWAAICwcAwRICViwQJMUb5ACMEKAUSoVqIAAAAA.YAAAAAAAAAAA"
-          }
-        ]
-      },
-      "id": "a912a9dd-1723-4ad0-b15b-98ad02fab66e",
-      "domains": ["subito.it"]
-    },
-    {
-      "click": {
         "optIn": "button.css-hxv78t",
         "presence": "div.qc-cmp2-summary-buttons"
       },
@@ -1637,22 +1550,6 @@
     {
       "click": {
         "optIn": "button#didomi-notice-agree-button",
-        "presence": "div#buttons"
-      },
-      "cookies": {
-        "optOut": [
-          {
-            "name": "didomi_token",
-            "value": "eyJ1c2VyX2lkIjoiMTgzYzE0MGQtZGQ3OS02MjQ3LWFmMjgtOWNjNDQ2OTUzZjY1IiwiY3JlYXRlZCI6IjIwMjItMTAtMTBUMDk6Mzc6MjkuMTMzWiIsInVwZGF0ZWQiOiIyMDIyLTEwLTEwVDA5OjM3OjI5LjEzM1oiLCJ2ZW5kb3JzIjp7ImVuYWJsZWQiOlsiZ29vZ2xlIiwiYzpwaXhlbGdvb2cteWJiOWQ0QXQiLCJjOm9uZm9jdXMtZVljN3pyV3AiLCJjOmthbWVsZW9vbi1jVHlLZXlLOSIsImM6ZGZwLVQ3VktBaUJQIiwiYzpwcmViaWQtWks1SFFBUGEiLCJjOnBpeGVsdHdpdC1GYU1kdzhNUiIsImM6bWVkaWFtZXRyaS1FNmF0dDk3UCIsImM6Z3JhcGVzaG90IiwiYzpmYWNlYm9vay1Ld3c4UjRFaCIsImM6ZGlkb21pLWFSR0YycnFVIiwiYzphY3BtLVZrUFo4SmU0IiwiYzppbnN0YWdyYW0tSFhVdEdOZVkiLCJjOmZhY2Vib29rYy1hUmQyUHhCUCIsImM6ZGFpbHltb3Rpby1uVlFCajJVQyIsImM6d2Vib3JhbWEtelVuSnFFYWciLCJjOmR5ZHUtYU5keGY0VjgiLCJjOndvbmRlcnB1c2gtWlZ5a0hoR2kiLCJjOnBpeGVsbGluay1meUtGM20zaCIsImM6bWljcm9zb2Z0LVJMNkN5RUJhIiwiYzpnb29nbGVzaWctblA2Ym1GYlEiLCJjOmdpZ3lhLVliV1ZDcFVMIiwiYzpzcGVlZGN1cnYteUY3VjM5R3QiLCJjOmNlZGV4aXMtNERNNDdyZmIiLCJjOm1pbGlicmlzLXJSd2hUR0FxIiwiYzpteWZlZWxiYS1tblJDR1VwSyIsImM6c2VsbGlnZW50LVpncXB5eEZrIiwiYzptZWRpYXJpdGhtLXlaQ2ozakJXIiwiYzphcHBsZS1SV0R0S0piMiIsImM6ZGV2aWNlY2FwLUpaVWNIQkhBIiwiYzpncmFwZXNob3QtdFBwYUdMclIiLCJjOm1pY3Jvc29mdC1hbmFseXRpY3MiLCJjOmF0aW50ZXJuZS1jV1FLSGVKWiIsImM6Z29vZ2xlZmlyLTJwSlFLRW5kIiwiYzphdGludGVybmUtSGdNa2lDSzkiXX0sInB1cnBvc2VzIjp7ImVuYWJsZWQiOlsiYXV0cmVzcHViLU1FN0pBNHRBIiwicHVibGljaXRlLU04R0VpN3p4IiwicGVyc29ubmFsaS1SYjNtd0pDbSIsIm1lc3VyZWRhLVZWcUNxbnFSIiwiYXVkaWVuY2VtLXhlZGVVMmdRIiwiZ2VvbG9jYXRpb25fZGF0YSIsImRldmljZV9jaGFyYWN0ZXJpc3RpY3MiXX0sInZlcnNpb24iOjIsImFjIjoiQVVhQUNBVVkuQUFBQSJ9"
-          }
-        ]
-      },
-      "id": "2f7dbe65-17ef-4c9d-b88b-42b0afe9d4fe",
-      "domains": ["lequipe.fr"]
-    },
-    {
-      "click": {
-        "optIn": "button#didomi-notice-agree-button",
         "optOut": "span.didomi-continue-without-agreeing",
         "presence": "div#buttons"
       },
@@ -1720,22 +1617,6 @@
       "cookies": {},
       "id": "f1502dfd-a03c-4ca1-ab5d-488b2e09b644",
       "domains": ["mondo.rs"]
-    },
-    {
-      "click": {
-        "optIn": "button#didomi-notice-agree-button",
-        "presence": "div#buttons"
-      },
-      "cookies": {
-        "optOut": [
-          {
-            "name": "euconsent-v2",
-            "value": "CPgocUAPgocUAAHABBENCjCgAAAAAAAAAAAAAAAAAAEhIAMAAQSCFQAYAAgkEMgAwABBIINABgACCQQiADAAEEgh0AGAAIJBEIAMAAQSCJQAYAAgkEUgAwABBIIA.YAAAAAAAAAAA"
-          }
-        ]
-      },
-      "id": "8622b7d2-8efa-4a6c-a9ee-4066d9a7accc",
-      "domains": ["abc.es"]
     },
     {
       "click": {
@@ -1899,23 +1780,6 @@
       "cookies": {},
       "id": "8e274753-a1ee-4e02-b131-fa937ab10aea",
       "domains": ["wetter.com"]
-    },
-    {
-      "click": {
-        "optIn": "button#didomi-notice-agree-button",
-        "presence": "div#buttons"
-      },
-      "cookies": {
-        "optIn": [],
-        "optOut": [
-          {
-            "name": "didomi_token",
-            "value": "eyJ1c2VyX2lkIjoiMTgzYzFkOTItMWIzOC02ZmRjLTk4MGEtNTRlNDAxZDk1ZDZjIiwiY3JlYXRlZCI6IjIwMjItMTAtMTBUMTI6MjM6MDMuOTgxWiIsInVwZGF0ZWQiOiIyMDIyLTEwLTEwVDEyOjIzOjAzLjk4MVoiLCJ2ZW5kb3JzIjp7ImRpc2FibGVkIjpbImdvb2dsZSIsImM6YWRvYmUtdGFnbWFuYWdlciIsImM6YWdub3BsYXktTXpZY0Y0SEYiLCJjOnB1YnN0YWNrLWlZaGZRM2hRIiwiYzpmYWNlYm9vay1iajRGSkZIVyIsImM6aW5zdGFncmFtIiwiYzpvbW5pdHVyZS1hZG9iZS1hbmFseXRpY3MiLCJjOnJlZC1ieS1zZnIiLCJjOmludGVsbGlhZCIsImM6aW1wYWN0LXJhZGl1cyIsImM6c2hhcnBzcHJpbmciLCJjOmJhdGNoLWpYUHhNTUxOIiwiYzpnb29nbGVhbmEtbjZVTWhKN2UiLCJjOmZhY2Vib29rcC1VRFU4WUtOZiIsImM6Z2V0c2l0ZWNvbi05Q3F6RzdaNiIsImM6ZnJvb21sZS00TnoyWER3TiIsImM6b3B0aW1pemVseS1Zd1ZxOU1XYiIsImM6dndvLWlDZTYyeGQ3IiwiYzptYXRoZXItZWNvbm9taWNzIiwiYzpob3RqYXIteW5GOG1hVVIiLCJjOmlvdGVjaG5vbC15WXBjZnRkeiIsImM6dHdpdHRlci0zdzMzOWNMNiIsImM6ZmFjZWJvb2stY29ubmVjdC16aW1tbyIsImM6aW5zdGFncmFtLWZobXJ4S01XIiwiYzpuZXh0cm9sbC1HRG5wQURHYiIsImM6emFsYW5kby1wVEtZVk1hYiIsImM6dmlydHVhbG1uLUVNQXpNTERXIiwiYzpwbWctWkUyQ3lDRmsiLCJjOm9tbmljb21tZS15UGlqN2dZWiIsImM6aW50ZXJwdWJsaS04SFo4UGZHMyIsImM6Z3NraW5uZXItblVFMzRQMkgiLCJjOnR3aXBlLUNraXROelhEIiwiYzp6ZWJlc3RvZi1jZDdOWUVMTCIsImM6eW91dHViZS1wcGRZd0RLcCIsImM6YWRzYW5kZGEtekdUR1JWSHciLCJjOmJsdWVjb25pYy1tZmNlUFVaOSJdfSwicHVycG9zZXMiOnsiZGlzYWJsZWQiOlsic29jaWFsX21lZGlhIiwidWl0Z2VicmVpZC1BTU4yY2hldCJdfSwidmVuZG9yc19saSI6eyJkaXNhYmxlZCI6WyJnb29nbGUiLCJjOmJsdWVjb25pYy1tZmNlUFVaOSJdfSwicHVycG9zZXNfbGkiOnsiZGlzYWJsZWQiOlsidWl0Z2VicmVpZC1BTU4yY2hldCJdfSwidmVyc2lvbiI6MiwiYWMiOiJBQUFBLkFBQUEifQ=="
-          }
-        ]
-      },
-      "id": "f11cf7cd-4f4d-4e22-b473-9d358d18a601",
-      "domains": ["gva.be"]
     },
     {
       "click": {
@@ -2236,18 +2100,6 @@
     },
     {
       "click": {
-        "optIn": "button#didomi-notice-agree-button",
-        "presence": "div#buttons"
-      },
-      "cookies": {
-        "optIn": [],
-        "optOut": [{ "name": "et_consent", "value": "false" }]
-      },
-      "id": "48f1ebe1-659a-4ded-9a87-28ab66616a70",
-      "domains": ["eltiempo.es"]
-    },
-    {
-      "click": {
         "optIn": "button#button_i_accept",
         "presence": "div#consent-info"
       },
@@ -2499,32 +2351,6 @@
       "cookies": { "optIn": [{ "name": "s_cc", "value": "true" }] },
       "id": "0b8969b6-d5a1-4358-967b-524a2c998233",
       "domains": ["dnb.no"]
-    },
-    {
-      "click": {
-        "optIn": "button#didomi-notice-agree-button",
-        "presence": "div#buttons"
-      },
-      "cookies": {
-        "optIn": [
-          {
-            "name": "cto_bundle",
-            "value": "VurNJF9SJTJCVmU3UXJ0OHFJT0REdm1ORHJMZmxxV0tNOFphejJCU0VEV0ZTanFHdTFwbFdNbThEVkJnSjI0dmdxa2RaQ3klMkZXT1JmJTJGek8wRnB2eTBZdmdZMkt0OVFZOHQ0TDMzc095WWtsT1RWZUV1bGslMkZJZ1FyVjR2THhFSyUyQkQ5NmFUS08"
-          },
-          {
-            "name": "euconsent-v2",
-            "value": "CPgvCMAPgvCMAAHABBENCkCsAP_AAH_AAAiQJDtf_X__b2_r-_5_f_t0eY1P9_7__-0zjhfdl-8N3f_X_L8X52M7vF36tq4KuR4ku3LBIUdlHOHcTUmw6okVryPsbk2cr7NKJ7PEmnMbOydYGH9_n1_z-ZKY7___f_7z_v-v___3____7-3f3__5___-__e_V__9zfn9_____9vP___9v-_9__________3_7994JCAEmGrcQBdiWOBNtGEUCIEYVhIdQKACigGFogMIHVwU7K4CfWECABAKAIwIgQ4AowYBAAABAEhEQEgR4IBAARAIAAQAKhEIACNgEFABYGAQACgGhYoxQBCBIQZEBEUpgQESJBQT2VCCUH-hphCHWWAFBo_4qEBEoAQrAiEhYOQ4IkBLxZIFmKN8gBGCFAKJUK1AAAAA.f_gAD_gAAAAA"
-          }
-        ],
-        "optOut": [
-          {
-            "name": "euconsent-v2",
-            "value": "CPgvCMAPgvCMAAHABBENCkCgAAAAAH_AAAiQAAASEAJMNW4gC7EscCbaMIoEQIwrCQ6gUAFFAMLRAYQOrgp2VwE-sIEACAUARgRAhwBRgwCAAACAJCIgJAjwQCAAiAQAAgAVCIQAEbAIKACwMAgAFANCxRigCECQgyICIpTAgIkSCgnsqEEoP9DTCEOssAKDR_xUICJQAhWBEJCwchwRICXiyQLMUb5ACMEKAUSoVqAA.YAAAD_gAAAAA"
-          }
-        ]
-      },
-      "id": "dad83ae7-5d03-4589-83af-83458f8c1518",
-      "domains": ["eldiario.es"]
     },
     {
       "click": {
@@ -2832,27 +2658,6 @@
     },
     {
       "click": {
-        "optIn": "button#didomi-notice-agree-button",
-        "presence": "div#buttons"
-      },
-      "cookies": {
-        "optIn": [
-          {
-            "name": "euconsent-v2",
-            "value": "CPg1oEAPg1oEAAHABBENCkCsAP_AAH_AAAAAJDtf_X__b2_r-_5_f_t0eY1P9_7__-0zjhfdl-8N3f_X_L8X52M7vF36tq4KuR4ku3LBIUdlHOHcTUmw6okVryPsbk2cr7NKJ7PEmnMbOydYGH9_n1_z-ZKY7___f_7z_v-v___3____7-3f3__5___-__e_V__9zfn9_____9vP___9v-_9__________3_7994JCAEmGrcQBdiWOBNtGEUCIEYVhIdQKACigGFogMIHVwU7K4CfWECABAKAIwIgQ4AowYBAAABAEhEQEgR4IBAARAIAAQAKhEIACNgEFABYGAQACgGhYoxQBCBIQZEBEUpgQESJBQT2VCCUH-hphCHWWAFBo_4qEBEoAQrAiEhYOQ4IkBLxZIFmKN8gBGCFAKJUK1AAAAA.f_gAD_gAAAAA"
-          },
-          {
-            "name": "cto_bundle",
-            "value": "oQm4Nl9nSHA5VSUyRk1aS1RvOTFWbWFpaEVpcDJRUlBpeW5Ea01TcllER01FeVBwSER0OEhhV0lJc2Q3ZzhZcllLaVRWMWVhVHZ3V1JrJTJGNjhvbnJ1SXd0Szl2clVXUThOaTlpNWthQk5XRHNYc1M5enQlMkZxOFhXTmZXWXN0YlN5TUJKaXIlMkJ5YkFUMnlRdTFjc0NHbnBvJTJGa2g5TTVRJTNEJTNE"
-          }
-        ],
-        "optOut": [{ "name": "aasd", "value": "2%7C1665736972486" }]
-      },
-      "id": "1365810a-360b-4204-8d09-aeff6ca2149b",
-      "domains": ["larazon.es"]
-    },
-    {
-      "click": {
         "optOut": "a#ensCall",
         "presence": "div.td-modal-cookie-content"
       },
@@ -2988,15 +2793,6 @@
       "cookies": {},
       "id": "7b299edf-ea10-472a-a3d9-cd622bde1ef9",
       "domains": ["mozzartsport.com"]
-    },
-    {
-      "click": {
-        "optIn": "button#didomi-notice-agree-button",
-        "presence": "div#buttons"
-      },
-      "cookies": { "optIn": [{ "name": "_gat_UA-134365382-1", "value": "1" }] },
-      "id": "79a0a4df-9d77-4a45-ac9b-2638338f090a",
-      "domains": ["extra.cz"]
     },
     {
       "click": {
@@ -3202,15 +2998,6 @@
       "cookies": {},
       "id": "1e55c3c3-63d2-45b2-8871-dfae1396c1a0",
       "domains": ["roblox.com"]
-    },
-    {
-      "click": {
-        "optIn": "button#didomi-notice-agree-button",
-        "presence": "div#didomi-popup"
-      },
-      "cookies": {},
-      "id": "f52698f6-efc9-4a8d-a425-e0e147a98c42",
-      "domains": ["leparisien.fr"]
     },
     {
       "click": {
@@ -3926,15 +3713,6 @@
     },
     {
       "click": {
-        "optIn": "button#didomi-notice-agree-button",
-        "presence": "div#didomi-popup"
-      },
-      "cookies": { "optOut": [] },
-      "id": "b459bcce-8602-4695-8ce0-d3eb4f0892cf",
-      "domains": ["ladepeche.fr"]
-    },
-    {
-      "click": {
         "optIn": "button.fc-cta-consent",
         "optOut": "button.fc-cta-do-not-consent",
         "presence": "div.fc-dialog-container"
@@ -3968,30 +3746,12 @@
     },
     {
       "click": {
-        "optIn": "button#didomi-notice-agree-button",
-        "presence": "div#didomi-popup"
-      },
-      "cookies": {},
-      "id": "6315f464-8f57-4d2d-9cc3-f1d44047cb01",
-      "domains": ["poslovni.hr", "reverso.net", "softonic.com"]
-    },
-    {
-      "click": {
         "optIn": "button#modalConfirmBtn",
         "presence": "div#gravitoCMP-modal-layer1"
       },
       "cookies": {},
       "id": "de4a2156-043d-431f-976c-03c2cd94ce2b",
       "domains": ["verkkouutiset.fi"]
-    },
-    {
-      "click": {
-        "optIn": "button#didomi-notice-agree-button",
-        "presence": "div#didomi-host"
-      },
-      "cookies": { "optIn": [{ "name": "_tt_enable_cookie", "value": "1" }] },
-      "id": "fd377be1-78c5-4bc9-bbc7-20af3ef8b361",
-      "domains": ["marmiton.org"]
     },
     {
       "click": {
@@ -4093,15 +3853,6 @@
     },
     {
       "click": {
-        "optIn": "button#didomi-notice-agree-button",
-        "presence": "div#didomi-host"
-      },
-      "cookies": { "optIn": [{ "name": "lcl_basicads", "value": "1" }] },
-      "id": "dbd52d0d-e1aa-4f47-b8c0-9b8ae3852520",
-      "domains": ["sydsvenskan.se"]
-    },
-    {
-      "click": {
         "optIn": "button#uc-btn-accept-banner",
         "optOut": "button#uc-btn-deny-banner",
         "presence": "div#uc-banner-modal"
@@ -4180,15 +3931,6 @@
       },
       "id": "5371fb3e-3242-4864-9443-62116afe5f3c",
       "domains": ["021.rs", "photobucket.com"]
-    },
-    {
-      "click": {
-        "optIn": "button#didomi-notice-agree-button",
-        "presence": "div#didomi-host"
-      },
-      "cookies": { "optIn": [{ "name": "s_cc", "value": "true" }] },
-      "id": "20bc1d08-5618-453c-ba9c-acd97095360c",
-      "domains": ["telecinco.es"]
     },
     {
       "click": {
@@ -4558,15 +4300,6 @@
       "cookies": { "optIn": [{ "name": "and_cba_EN_US", "value": "true" }] },
       "id": "35a8e0de-9308-4dfe-abc9-764a9e3833ec",
       "domains": ["android.com"]
-    },
-    {
-      "click": {
-        "optIn": "button#didomi-notice-agree-button",
-        "presence": "div#didomi-notice"
-      },
-      "cookies": {},
-      "id": "8c58a553-8147-4972-9d0c-8e5c39cd1b96",
-      "domains": ["giphy.com"]
     },
     {
       "click": { "optIn": "a.cc-dismiss", "presence": "div.cc-window" },


### PR DESCRIPTION
Merge rules for sites using Didomi CMP
Removed non-functional cookie rules and merged the rules for: leboncoin.fr, rtbf.be, 20minutos.es, sudinfo.be, elpais.com, sinoptik.bg, subito.it, lequipe.fr, abc.es, gva.be, eltiempo.es, eldiario.es, larazon.es, extra.cz, leparisien.fr, ladepeche.fr, marmiton.org, poslovni.hr, reverso.net, softonic.com, sydsvenskan.se, telecinco.es, giphy.com with af4c5b38-d210-472b-9a07-21cbe53c85ab.