### PR TITLE
Removed rules for iprima.cz, elmundo.es, marca.com

### DIFF
--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -4957,18 +4957,6 @@
         "elperiodico.com",
         "dumpert.nl"
       ]
-    },
-    {
-      "cookies": {
-        "optOut": [
-          {
-            "name": "euconsent-v2",
-            "value": "CPkVv0APkVv0AAHABBENCuCgAAAAAAAAAAAAAAAAAAEEoAMAAQSXDQAYAAgkuKgAwABBJcpABgACCS46ADAAEElyEAGAAIJLhIAMAAQSXGQAYAAgkuAA.YAAAAAAAAAAA"
-          }
-        ]
-      },
-      "id": "ec47c90f-8e92-469b-9a6d-311715557805",
-      "domains": ["iprima.cz", "elmundo.es", "marca.com"]
     }
   ]
 }


### PR DESCRIPTION
Removed rules for iprima.cz, elmundo.es, marca.com for further investigation. For now, the rule cannot be fixed using cookies or CSS selectors.