### PR TITLE
Add new rules and update existing rules - 2nd pass through the list (3)

### DIFF
--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -18,6 +18,10 @@
       "cookies": {},
       "id": "6c7366a0-4762-47b9-8eeb-04e86cc7a0cc",
       "domains": [
+        "proximus.be",
+        "dn.no",
+        "elisa.fi",
+        "blick.ch",
         "soundcloud.com",
         "adevarul.ro",
         "tvn24.pl",
@@ -99,7 +103,6 @@
         "otomoto.pl",
         "sport.pl",
         "novini.bg",
-        "espn.com",
         "suomi24.fi",
         "playtech.ro",
         "sbb.ch",
@@ -109,7 +112,6 @@
         "ziare.com",
         "rts.ch",
         "irishexaminer.com",
-        "ikea.com",
         "tripadvisor.it",
         "thejournal.ie",
         "superbet.ro",
@@ -514,6 +516,10 @@
       "cookies": {},
       "id": "0b42c238-b54d-4106-8d9a-81df5bc0b3ae",
       "domains": [
+        "drei.at",
+        "ikea.com",
+        "search.ch",
+        "centrum.sk",
         "zoom.us",
         "pluska.sk",
         "hp.com",
@@ -843,6 +849,7 @@
       "cookies": {},
       "id": "af4c5b38-d210-472b-9a07-21cbe53c85ab",
       "domains": [
+        "jeuxvideo.com",
         "24sata.hr",
         "nova.cz",
         "lidovky.cz",
@@ -868,7 +875,6 @@
         "eldiario.es",
         "larazon.es",
         "extra.cz",
-        "leparisien.fr",
         "ladepeche.fr",
         "marmiton.org",
         "poslovni.hr",
@@ -1190,11 +1196,19 @@
     {
       "click": {
         "optIn": "button.fc-cta-consent",
-        "presence": "div.fc-footer-buttons-container"
+        "presence": "div.fc-consent-root"
       },
       "cookies": {},
       "id": "ed097835-3d75-4864-8cdf-ea8fb19b033c",
-      "domains": ["dnes.bg", "hbr.org", "dennikn.sk"]
+      "domains": [
+        "dnes.bg",
+        "hbr.org",
+        "dennikn.sk",
+        "jn.pt",
+        "ojogo.pt",
+        "echo24.cz",
+        "klik.hr"
+      ]
     },
     {
       "click": {
@@ -1247,11 +1261,11 @@
       "click": {
         "optIn": "button.iubenda-cs-accept-btn",
         "optOut": "button.iubenda-cs-close-btn",
-        "presence": "div.iubenda-cs-opt-group"
+        "presence": "div#iubenda-cs-banner"
       },
       "cookies": {},
       "id": "2625ca4e-dd77-4e72-a6d0-c959f3575ad8",
-      "domains": ["3bmeteo.com"]
+      "domains": ["3bmeteo.com", "ansa.it"]
     },
     {
       "click": { "optIn": "button", "presence": "div.gdprcookie" },
@@ -1395,7 +1409,15 @@
       },
       "cookies": {},
       "id": "c1d7be10-151e-4a66-b83b-31a762869a97",
-      "domains": ["jofogas.hu", "orange.fr", "meteofrance.com", "subito.it"]
+      "domains": [
+        "leparisien.fr",
+        "jofogas.hu",
+        "orange.fr",
+        "meteofrance.com",
+        "subito.it",
+        "hasznaltauto.hu",
+        "orange.sk"
+      ]
     },
     {
       "click": {
@@ -1483,7 +1505,16 @@
       },
       "cookies": {},
       "id": "25dd408a-0a98-4e93-992c-abd320255cd1",
-      "domains": ["newsit.gr", "protothema.gr", "newsbomb.gr", "youweekly.gr"]
+      "domains": [
+        "newsit.gr",
+        "protothema.gr",
+        "newsbomb.gr",
+        "youweekly.gr",
+        "vrisko.gr",
+        "index.hu",
+        "meteo.gr",
+        "fantacalcio.it"
+      ]
     },
     {
       "click": {
@@ -1557,15 +1588,6 @@
       "cookies": {},
       "id": "679d7000-cd04-4c35-bbf8-21263a2ff357",
       "domains": ["ampparit.com"]
-    },
-    {
-      "click": {
-        "optIn": "button.css-k8o10q",
-        "presence": "div.qc-cmp2-summary-buttons"
-      },
-      "cookies": {},
-      "id": "8cffbd7c-cb54-46bb-9e84-4395001479fc",
-      "domains": ["meteo.gr"]
     },
     {
       "click": { "optIn": "button.css-k8o10q", "presence": "div#qc-cmp2-ui" },
@@ -1651,10 +1673,7 @@
         "optIn": "button.css-78i25x",
         "presence": "div#qc-cmp2-container"
       },
-      "cookies": {
-        "optIn": [{ "name": "_tt_enable_cookie", "value": "1" }],
-        "optOut": [{ "name": "addtl_consent", "value": "1~" }]
-      },
+      "cookies": {},
       "id": "21593dac-f469-4206-87d9-044e6d69404b",
       "domains": ["mirror.co.uk"]
     },
@@ -1674,7 +1693,7 @@
         "optOut": "a.js-cookies-info-reject",
         "presence": "div.cookies-info__buttons"
       },
-      "cookies": { "optIn": [{ "name": "CBARIH", "value": "1" }] },
+      "cookies": { "optOut": [{ "name": "CBARIH", "value": "1" }] },
       "id": "c7a067c4-a365-4497-a990-c042545dfd6c",
       "domains": ["alza.cz"]
     },
@@ -1700,10 +1719,7 @@
         "optIn": "button.css-k8o10q",
         "presence": "div#qc-cmp2-container"
       },
-      "cookies": {
-        "optIn": [{ "name": "inx_checker2", "value": "1" }],
-        "optOut": [{ "name": "addtl_consent", "value": "1~" }]
-      },
+      "cookies": {},
       "id": "d1b9f7af-26d3-4f1b-812c-9f8cf41da900",
       "domains": ["femina.hu"]
     },
@@ -1713,12 +1729,7 @@
         "optOut": "a#truste-consent-required2",
         "presence": "div#truste-consent-buttons"
       },
-      "cookies": {
-        "optIn": [{ "name": "cmapi_cookie_privacy", "value": "permit 1,2,3" }],
-        "optOut": [
-          { "name": "cmapi_cookie_privacy", "value": "permit 1 required" }
-        ]
-      },
+      "cookies": {},
       "id": "450e91f1-22ee-4718-9e98-05f831adfeff",
       "domains": ["poste.it"]
     },
@@ -1744,15 +1755,7 @@
         "optIn": "button#almacmp-modalConfirmBtn",
         "presence": "div.almacmp-controls"
       },
-      "cookies": {
-        "optIn": [],
-        "optOut": [
-          {
-            "name": "gravitoData",
-            "value": "{\"TCString\":\"CPgrvQAPgrvQABUAJAFICkCgAAAAAAAAAApAAAAPigOgALAAqABkADwAIAAZAA0AB8AEQAJ4AcwA_ACEAEwANEAbIBCACIgEWAJEAWkAwIBigDPgHUATIAvMBggD4gCQkA8ABYAFQAMgAeABAADIAGgARAAngBzAD8AIQAbIBigF5hoAQA2QC0iIAIA2RUAIAtIC8xkAEBeY6AoAAsACoAGQAQAAyABoAD4AIgATwA5gB-AEwANEAbIBFgC0gGKAOoAmQBeZCAKAAsADIBaQDFAHUJQCAAFgAZACIANkAtIBigDqALzKQDwAFgAVAAyACAAGQANAAiABPADmAH4AaIA2QCLAGKAXmAAA.YAAAAAAAAIAA\",\"NonTCFVendors\":[{\"id\":1,\"name\":\"Facebook\",\"consent\":false},{\"id\":3,\"name\":\"Google\",\"consent\":false},{\"id\":4,\"name\":\"Chartbeat\",\"consent\":false},{\"id\":5,\"name\":\"Giosg\",\"consent\":false},{\"id\":6,\"name\":\"Hotjar\",\"consent\":false},{\"id\":7,\"name\":\"Qualifio\",\"consent\":false},{\"id\":8,\"name\":\"Questback\",\"consent\":false},{\"id\":9,\"name\":\"Twitter\",\"consent\":false},{\"id\":10,\"name\":\"Wordpress\",\"consent\":false},{\"id\":15,\"name\":\"Linkedin\",\"consent\":false},{\"id\":16,\"name\":\"Microsoft\",\"consent\":false},{\"id\":17,\"name\":\"OneSignal\",\"consent\":false},{\"id\":18,\"name\":\"AppCues\",\"consent\":false},{\"id\":19,\"name\":\"Vimeo\",\"consent\":false},{\"id\":21,\"name\":\"Finnchat\",\"consent\":false},{\"id\":22,\"name\":\"Lekane\",\"consent\":false},{\"id\":23,\"name\":\"Zendesk\",\"consent\":false},{\"id\":24,\"name\":\"Serviceform\",\"consent\":false},{\"id\":25,\"name\":\"Smilee\",\"consent\":false},{\"id\":26,\"name\":\"Calendly\",\"consent\":false},{\"id\":27,\"name\":\"Apple\",\"consent\":false},{\"id\":28,\"name\":\"Cavai\",\"consent\":false},{\"id\":29,\"name\":\"Selligent\",\"consent\":false}]}"
-          }
-        ]
-      },
+      "cookies": {},
       "id": "abb44f4b-bc8a-49bf-8f8c-204fe33806e9",
       "domains": ["kauppalehti.fi"]
     },
@@ -1761,10 +1764,7 @@
         "optIn": "button.css-1j8kkja",
         "presence": "div#qc-cmp2-container"
       },
-      "cookies": {
-        "optIn": [{ "name": "_gat_UA-482127-5", "value": "1" }],
-        "optOut": [{ "name": "addtl_consent", "value": "1~" }]
-      },
+      "cookies": {},
       "id": "1b1bdbb4-089c-45dc-9d42-e87a1fa85882",
       "domains": ["news247.gr"]
     },
@@ -1772,7 +1772,7 @@
       "click": {
         "optIn": "a#CybotCookiebotDialogBodyLevelButtonLevelOptinAllowAll",
         "optOut": "a#CybotCookiebotDialogBodyLevelButtonLevelOptinDeclineAll",
-        "presence": "div#CybotCookiebotDialogBodyLevelButtonLevelOptinAllowallSelectionWrapper"
+        "presence": "div#CybotCookiebotDialog"
       },
       "cookies": {
         "optIn": [],
@@ -1812,7 +1812,7 @@
         "optOut": [
           {
             "name": "cookiesconsent",
-            "value": "{\"personalad\":true,\"lastvisited\":true}"
+            "value": "{\"personalad\":false,\"lastvisited\":false}"
           }
         ]
       },
@@ -1842,12 +1842,6 @@
         "presence": "div.fc-footer-buttons"
       },
       "cookies": {
-        "optIn": [
-          {
-            "name": "FCNEC",
-            "value": "%5B%5B%22AKsRol87glA3rE51czKXQKdf0h9rbPT6f6Ctv5K6Ly3uAPIiyCzG5ShYOj9VysWIvTYhEVgeP0w6h-BRczbvzoq2udJFkGQhxjkFDhtUBITXuzgG0YH1LbU5ktUMjTxUK28S_Hj1S3ZmOWj3eVcRUj8NoGJZtsurBg%3D%3D%22%5D%2Cnull%2C%5B%5D%5D"
-          }
-        ],
         "optOut": [
           {
             "name": "FCCDCF",
@@ -1864,7 +1858,6 @@
         "presence": "div.sfc-col-lg-3"
       },
       "cookies": {
-        "optIn": [{ "name": "_fbp", "value": "fb.1.1665489826730.1028115920" }],
         "optOut": [{ "name": "RABO_PSL", "value": "1" }]
       },
       "id": "fe8a3adb-ce3c-4dd6-83db-772e71674da3",
@@ -1872,7 +1865,7 @@
     },
     {
       "click": { "optIn": "a.cmptxt_btn_yes", "presence": "div.cmpboxbtns" },
-      "cookies": { "optOut": [{ "name": "__cmpcc", "value": "1" }] },
+      "cookies": {},
       "id": "27572d79-fc44-49f0-b271-bd44e76f3a3f",
       "domains": ["informer.rs"]
     },
@@ -1882,10 +1875,7 @@
         "presence": "div#popup-buttons"
       },
       "cookies": {
-        "optIn": [
-          { "name": "cookie-agreed", "value": "2" },
-          { "name": "cookie-agreed-version", "value": "1.0.0" }
-        ],
+        "optIn": [{ "name": "cookie-agreed", "value": "2" }],
         "optOut": []
       },
       "id": "34e9d8ee-5e8d-462c-ab39-d25260124cf6",
@@ -1937,21 +1927,7 @@
         "optIn": "button.css-k8o10q",
         "presence": "div#qc-cmp2-container"
       },
-      "cookies": {
-        "optIn": [
-          {
-            "name": "cto_bundle",
-            "value": "dmF2h19lNUpidloybGpaRGpGSTJtb1dKbiUyQnAlMkJZa0Z2UzZJUURoNDNHc1BreUM5UnJScHVMSHdBOElGTGMwcGd1QmxDa09nSThkNUJPdmU2cFZwVXQ2bUl0R0k3WmZKU29idWo0ek9KSDklMkZyU2VFM0hxYjglMkIxelRseVdQRnklMkJzMFpYelM"
-          }
-        ],
-        "optOut": [
-          { "name": "addtl_consent", "value": "1~" },
-          {
-            "name": "euconsent-v2",
-            "value": "CPgvCMAPgvCMAAKAsAELCkCgAAAAAH_AAAyIAAASIAJMNW4gC7MscGbQMIoEQIwrCQqgUAEFAMLRAYAODgp2VgE-sIEACAUARgRAhwBRgQCAAASAJCIAJAiwQAAAiAQAAgARCIQAMDAILACwMAgABANAxRCgAECQgyICIpTAgKgSCA1sqEEoLpDTCAOssAKCRGxUACIJARWAAICwcAwRICViwQJMUb5ACMEKAUSoVqIAAAAA.YAAAAAAAAAAA"
-          }
-        ]
-      },
+      "cookies": {},
       "id": "c0e69dcc-9602-4d7a-89b8-a4a06f0432ca",
       "domains": ["athensmagazine.gr"]
     },
@@ -1960,12 +1936,7 @@
         "optIn": "button.cookie-banner-lgpd_accept-button",
         "presence": "div#cookie-banner-lgpd"
       },
-      "cookies": {
-        "optIn": [
-          { "name": "cookie-banner-accepted-version", "value": "1.3.2.1" }
-        ],
-        "optOut": []
-      },
+      "cookies": {},
       "id": "90b8eda3-d964-4301-94fc-646e92d33d56",
       "domains": ["globo.com"]
     },
@@ -2071,21 +2042,7 @@
         "optIn": "button.css-1x99van",
         "presence": "div.qc-cmp2-summary-buttons"
       },
-      "cookies": {
-        "optIn": [
-          {
-            "name": "euconsent-v2",
-            "value": "CPgzfGvPgzfGvAKAmAENCkCsAP_AAH_AAAwIJDtd_H__bW9r-f5_aft0eY1P9_r37uQzDhfNk-8F3L_W_LwX52E7NF36tq4KmR4ku1LBIUNlHMHUDUmwaokVryHsak2cpzNKJ7BEknMZOydYGF9vmxtj-QKY7_5_dzbx2D-t_9v239z3z81Xn3d53-_03LCdV5_9Dfn9fR_bc9KPt_58v8v8_____3_e__3_7994JEAEmGrcQBdmWODNoGEUCIEYVhIVQKACCgGFogMAHBwU7KwCfWECABAKAIwIgQ4AowIBAAAJAEhEAEgRYIAAARAIAAQAIhEIAGBgEFgBYGAQAAgGgYohQACBIQZEBAUpgQFQJBAa2VCCUF0hphAHWWAFBIjYqABEEgIrAAEBYOAYIkBKxYIEmKN8gBGCFAKJUK1EAAAA.f_gAAAAAAAAA"
-          }
-        ],
-        "optOut": [
-          {
-            "name": "euconsent-v2",
-            "value": "CPgzdxQPgzdxQAKAmBENCkCgAAAAAH_AAAwIAAASIAJMNW4gC7MscGbQMIoEQIwrCQqgUAEFAMLRAYAODgp2VgE-sIEACAUARgRAhwBRgQCAAASAJCIAJAiwQAAAiAQAAgARCIQAMDAILACwMAgABANAxRCgAECQgyICApTAgKgSCA1sqEEoLpDTCAOssAKCRGxUACIJARWAAICwcAwRICViwQJMUb5ACMEKAUSoVqIAAAAA.YAAAAAAAAAAA"
-          },
-          { "name": "addtl_consent", "value": "1~" }
-        ]
-      },
+      "cookies": {},
       "id": "edaa2c50-1fbc-4287-8d15-68af2b5dc1bf",
       "domains": ["express.co.uk"]
     },
@@ -2104,15 +2061,7 @@
         "optIn": "button.css-1lgi3ta",
         "presence": "div#qc-cmp2-container"
       },
-      "cookies": {
-        "optOut": [
-          {
-            "name": "euconsent-v2",
-            "value": "CPgyVIAPgyVIAAKAsAELCkCgAAAAAH_AAAyIAAASIAJMNW4gC7MscGbQMIoEQIwrCQqgUAEFAMLRAYAODgp2VgE-sIEACAUARgRAhwBRgQCAAASAJCIAJAiwQAAAiAQAAgARCIQAMDAILACwMAgABANAxRCgAECQgyICIpTAgKgSCA1sqEEoLpDTCAOssAKCRGxUACIJARWAAICwcAwRICViwQJMUb5ACMEKAUSoVqIAAAAA.YAAAAAAAAAAA"
-          },
-          { "name": "addtl_consent", "value": "1~" }
-        ]
-      },
+      "cookies": {},
       "id": "9e16f526-4d46-4c2e-a3ed-d3b43d67b4fb",
       "domains": ["pronews.gr"]
     },
@@ -2167,9 +2116,16 @@
       "click": {
         "optIn": "button#CybotCookiebotDialogBodyLevelButtonLevelOptinAllowAll",
         "optOut": "button#CybotCookiebotDialogBodyButtonDecline",
-        "presence": "div.CybotCookiebotDialogContentWrapper"
+        "presence": "div#CybotCookiebotDialog"
       },
-      "cookies": {},
+      "cookies": {
+        "optOut": [
+          {
+            "name": "CookieConsent",
+            "value": "{stamp:%27m3maYSZu/SYJKH8MjsFeXQqfJ6HEoUz/rOOar/5mBa4CquRWj+4qYw==%27%2Cnecessary:true%2Cpreferences:false%2Cstatistics:false%2Cmarketing:false%2Cver:3%2Cutc:1665654078504%2Ciab2:%27CPgyVIAPgyVIACGABBENCkCgAAAAAH_AAAAAAAALzgFAAgABkAEQAJ4AfgCLAGKANoAmQBeYAwYAOACAAGQARAAngGKANoAvMUADAMUAbQBeYwAEAYoBeZQAMADIAIgATwCLAGKANoSABABEANoQAAgG0AAA.YAAAAAAAAAAA%27%2Cgacm:%271~%27%2Cregion:%27ro%27}"
+          }
+        ]
+      },
       "id": "1006f951-cd51-47cc-9527-5036cef4b85a",
       "domains": ["politiken.dk"]
     },
@@ -2178,28 +2134,7 @@
         "optIn": "button#almacmp-modalConfirmBtn",
         "presence": "div.almacmp-controls"
       },
-      "cookies": {
-        "optIn": [
-          {
-            "name": "gravitoData",
-            "value": "{\"TCString\":\"CPgyVIAPgyVIABUAJAFICkCsAP_AAH_AAApAHxQIwAFgAQAAqABkADwAIAAZAA0AB8AEQAI4ATwAqABbADmAH4AQUAhACFAEwANEAbIBCACIgEWAJEATsAtIBgQDFAHUAP0AmQBbIC8wHxAfFAdAAWABUADIAHgAQAAyABoAD4AIgATwA5gB-AEIAJgAaIA2QCEAERAIsASIAtIBgQDFAGfAOoAmQBeYDBAHxAEhIB4ACwAKgAZAA8ACAAGQANAAiABPADmAH4AQgA2QDFALzDQAgBsgFpEQAQBsioAQBaQF5jIAIC8x0BQABYAFQAMgAgABkADQAHwARAAngBzAD8AJgAaIA2QCLAFpAMUAdQBMgC8yEAUABYAGQC0gGKAOoSgEAALAAyAEQAbIBaQDFAHUAXmUgHgALAAqABkAEAAMgAaABEACeAHMAPwA0QBsgEWAMUAvMAAA.YAAAAAAAAMAA\",\"NonTCFVendors\":[{\"id\":1,\"name\":\"Facebook\",\"consent\":true},{\"id\":3,\"name\":\"Google\",\"consent\":true},{\"id\":4,\"name\":\"Chartbeat\",\"consent\":true},{\"id\":5,\"name\":\"Giosg\",\"consent\":true},{\"id\":6,\"name\":\"Hotjar\",\"consent\":true},{\"id\":7,\"name\":\"Qualifio\",\"consent\":true},{\"id\":8,\"name\":\"Questback\",\"consent\":true},{\"id\":9,\"name\":\"Twitter\",\"consent\":true},{\"id\":10,\"name\":\"Wordpress\",\"consent\":true},{\"id\":15,\"name\":\"Linkedin\",\"consent\":true},{\"id\":16,\"name\":\"Microsoft\",\"consent\":true},{\"id\":17,\"name\":\"OneSignal\",\"consent\":true},{\"id\":18,\"name\":\"AppCues\",\"consent\":true},{\"id\":19,\"name\":\"Vimeo\",\"consent\":true},{\"id\":21,\"name\":\"Finnchat\",\"consent\":true},{\"id\":22,\"name\":\"Lekane\",\"consent\":true},{\"id\":23,\"name\":\"Zendesk\",\"consent\":true},{\"id\":24,\"name\":\"Serviceform\",\"consent\":true},{\"id\":25,\"name\":\"Smilee\",\"consent\":true},{\"id\":26,\"name\":\"Calendly\",\"consent\":true},{\"id\":27,\"name\":\"Apple\",\"consent\":true},{\"id\":28,\"name\":\"Cavai\",\"consent\":true},{\"id\":29,\"name\":\"Selligent\",\"consent\":true}]}"
-          },
-          {
-            "name": "__nettix-vendor-consent",
-            "value": "{\"standardPurpose\":[1,2,3,4,5,6,7,8,9,10],\"vendorConsents\":{\"1\":true,\"3\":true,\"4\":true,\"5\":true,\"6\":true,\"7\":true,\"8\":true,\"9\":true,\"10\":true,\"11\":true,\"15\":true,\"16\":true,\"17\":true,\"18\":true,\"19\":true,\"21\":true,\"22\":true,\"23\":true,\"24\":true,\"25\":true,\"26\":true,\"27\":true,\"28\":true,\"29\":true,\"30\":true,\"32\":true,\"50\":true,\"52\":true,\"62\":true,\"68\":true,\"71\":true,\"79\":true,\"84\":true,\"91\":true,\"115\":true,\"126\":true,\"130\":true,\"132\":true,\"133\":true,\"152\":true,\"209\":true,\"217\":true,\"264\":true,\"273\":true,\"278\":true,\"290\":true,\"315\":true,\"361\":true,\"385\":true,\"394\":true,\"415\":false,\"468\":true,\"506\":true,\"612\":true,\"729\":true,\"755\":true,\"772\":false,\"994\":true}}"
-          }
-        ],
-        "optOut": [
-          {
-            "name": "gravitoData",
-            "value": "{\"TCString\":\"CPgyVIAPgyVIABUAJAFICkCgAAAAAAAAAApAAAAPigAAEhIB4ACwAKgAZAA8ACAAGQANAAiABPADmAH4AQgA2QDFALzDQAgBsgFpEQAQBsioAQBaQF5jIAIC8x0BQABYAFQAMgAgABkADQAHwARAAngBzAD8AJgAaIA2QCLAFpAMUAdQBMgC8yEAUABYAGQC0gGKAOoSgEAALAAyAEQAbIBaQDFAHUAXmUgHgALAAqABkAEAAMgAaABEACeAHMAPwA0QBsgEWAMUAvMA.YAAAAAAAAIAA\",\"NonTCFVendors\":[{\"id\":1,\"name\":\"Facebook\",\"consent\":false},{\"id\":3,\"name\":\"Google\",\"consent\":false},{\"id\":4,\"name\":\"Chartbeat\",\"consent\":false},{\"id\":5,\"name\":\"Giosg\",\"consent\":false},{\"id\":6,\"name\":\"Hotjar\",\"consent\":false},{\"id\":7,\"name\":\"Qualifio\",\"consent\":false},{\"id\":8,\"name\":\"Questback\",\"consent\":false},{\"id\":9,\"name\":\"Twitter\",\"consent\":false},{\"id\":10,\"name\":\"Wordpress\",\"consent\":false},{\"id\":15,\"name\":\"Linkedin\",\"consent\":false},{\"id\":16,\"name\":\"Microsoft\",\"consent\":false},{\"id\":17,\"name\":\"OneSignal\",\"consent\":false},{\"id\":18,\"name\":\"AppCues\",\"consent\":false},{\"id\":19,\"name\":\"Vimeo\",\"consent\":false},{\"id\":21,\"name\":\"Finnchat\",\"consent\":false},{\"id\":22,\"name\":\"Lekane\",\"consent\":false},{\"id\":23,\"name\":\"Zendesk\",\"consent\":false},{\"id\":24,\"name\":\"Serviceform\",\"consent\":false},{\"id\":25,\"name\":\"Smilee\",\"consent\":false},{\"id\":26,\"name\":\"Calendly\",\"consent\":false},{\"id\":27,\"name\":\"Apple\",\"consent\":false},{\"id\":28,\"name\":\"Cavai\",\"consent\":false},{\"id\":29,\"name\":\"Selligent\",\"consent\":false}]}"
-          },
-          {
-            "name": "__nettix-vendor-consent: \"{\"standardPurpose\":[],\"vendorConsents\"",
-            "value": "{\"1\":false,\"3\":false,\"4\":false,\"5\":false,\"6\":false,\"7\":false,\"8\":false,\"9\":false,\"10\":false,\"11\":false,\"15\":false,\"16\":false,\"17\":false,\"18\":false,\"19\":false,\"21\":false,\"22\":false,\"23\":false,\"24\":false,\"25\":false,\"26\":false,\"27\":false,\"28\":false,\"29\":false,\"30\":false,\"32\":false,\"50\":false,\"52\":false,\"62\":false,\"68\":false,\"71\":false,\"79\":false,\"84\":false,\"91\":false,\"115\":false,\"126\":false,\"130\":false,\"132\":false,\"133\":false,\"152\":false,\"209\":false,\"217\":false,\"264\":false,\"273\":false,\"278\":false,\"290\":false,\"315\":false,\"361\":false,\"385\":false,\"394\":false,\"415\":false,\"468\":false,\"506\":false,\"612\":false,\"729\":false,\"755\":false,\"772\":false,\"994\":false}}"
-          }
-        ]
-      },
+      "cookies": {},
       "id": "7e5d072f-ea5a-4a82-9ea4-3bbf06d5cc8d",
       "domains": ["nettiauto.com"]
     },
@@ -2208,25 +2143,7 @@
         "optIn": "button.css-11sahre",
         "presence": "div.qc-cmp2-summary-buttons"
       },
-      "cookies": {
-        "optIn": [
-          {
-            "name": "cto_bundle",
-            "value": "9Qphil9ZWTYxVEFFNngyNEpkS1JHYU1lVXRjWFpIVUJkOHpGdjdHNnd6VVRKSmN6ZWNkdElxc1NuOEVRMGNWYzNodnJhdUNhMVFuU2h5MFIlMkJYMENEWTNUc1dzdmM1Q2I4NyUyRlFFNjdCcWJyb1lCeGtYblRiN0hYJTJGTXJLSU9yWFpOTTVaMm1WSmQ4TkZyWVkwJTJGV21IJTJGQWo4d3d3JTNEJTNE"
-          },
-          {
-            "name": "euconsent-v2",
-            "value": "CPgyVIAPgyVIAAKAsAELCkCsAP_AAH_AAAyIJDtd_H__bW9r-f5_aft0eY1P9_r37uQzDhfNk-8F3L_W_LwX52E7NF36tq4KmR4ku1LBIUNlHMHUDUmwaokVryHsak2cpzNKJ7BEknMZOydYGF9vmxtj-QKY7_5_d3bx2D-t_9v239z3z81Xn3d53-_03LCdV5_9Dfn9fR_bc9KPt_58v8v8_____3_e__3_7994JEAEmGrcQBdmWODNoGEUCIEYVhIVQKACCgGFogMAHBwU7KwCfWECABAKAIwIgQ4AowIBAAAJAEhEAEgRYIAAARAIAAQAIhEIAGBgEFgBYGAQAAgGgYohQACBIQZEBEUpgQFQJBAa2VCCUF0hphAHWWAFBIjYqABEEgIrAAEBYOAYIkBKxYIEmKN8gBGCFAKJUK1EAAAA.YAAAAAAAAAAA"
-          }
-        ],
-        "optOut": [
-          { "name": "addtl_consent", "value": "1~" },
-          {
-            "name": "euconsent-v2",
-            "value": "CPgyVIAPgyVIAAKAsAELCkCgAAAAAH_AAAyIAAASIAJMNW4gC7MscGbQMIoEQIwrCQqgUAEFAMLRAYAODgp2VgE-sIEACAUARgRAhwBRgQCAAASAJCIAJAiwQAAAiAQAAgARCIQAMDAILACwMAgABANAxRCgAECQgyICIpTAgKgSCA1sqEEoLpDTCAOssAKCRGxUACIJARWAAICwcAwRICViwQJMUb5ACMEKAUSoVqIAAAAA.YAAAAAAAAAAA"
-          }
-        ]
-      },
+      "cookies": {},
       "id": "74f5fa98-df50-4caf-b1cd-6af3b2812432",
       "domains": ["sportdog.gr"]
     },
@@ -2235,12 +2152,7 @@
         "optIn": "button.js-accept",
         "presence": "div.cookie-banner-buttons"
       },
-      "cookies": {
-        "optIn": [
-          { "name": "EMAGROSESSID", "value": "o0jde53fk36pv9a0fhrj7rlt7f" }
-        ],
-        "optOut": [{ "name": "gdpr_consent_type", "value": "1" }]
-      },
+      "cookies": {},
       "id": "e78a3fdb-bcba-402c-b2da-63994aba1b30",
       "domains": ["emag.hu"]
     },
@@ -2249,34 +2161,20 @@
         "optIn": "button.css-b2defl",
         "presence": "div#qc-cmp2-container"
       },
-      "cookies": {
-        "optIn": [
-          {
-            "name": "cto_bundle",
-            "value": "ZnPA8F9mTEglMkZlTFJrYUJQdzFrbmlLaGZmNGkwMGZ0S2tXVWgyWno5QXFhbDc3T0JHYVEwbUsxNFljYSUyRnpKUjBhZlRKRHJHdjg4elFjOXRlQjUwMlVTekhRaEMwdTdBSndSZTFpZFMzQ2FsODhJdGREJTJGVUl5VEJsbXBVbTFMOEV2bE1PR2pyM2s1Uzd6WkMxS0JiUWM3WkltZHclM0QlM0Q"
-          },
-          {
-            "name": "euconsent-v2",
-            "value": "CPgyVIAPgyVIAAKAsAITCkCsAP_AAH_AABCYJDtd_H__bW9r-f5_aft0eY1P9_r37uQzDhfNk-8F3L_W_LwX52E7NF36tq4KmR4ku1LBIUNlHMHUDUmwaokVryHsak2cpzNKJ7BEknMZOydYGF9vmxtj-QKY7_5_d3bx2D-t_9v239z3z81Xn3d53-_03LCdV5_9Dfn9fR_bc9KPt_58v8v8_____3_e__3_7994JEAEmGrcQBdmWODNoGEUCIEYVhIVQKACCgGFogMAHBwU7KwCfWECABAKAIwIgQ4AowIBAAAJAEhEAEgRYIAAARAIAAQAIhEIAGBgEFgBYGAQAAgGgYohQACBIQZEBEUpgQFQJBAa2VCCUF0hphAHWWAFBIjYqABEEgIrAAEBYOAYIkBKxYIEmKN8gBGCFAKJUK1EAAAA.f_gAAAAAAAAA"
-          }
-        ],
-        "optOut": [
-          {
-            "name": "euconsent-v2",
-            "value": "CPgyVIAPgyVIAAKAsBITCkCgAAAAAH_AABCYAAASIAJMNW4gC7MscGbQMIoEQIwrCQqgUAEFAMLRAYAODgp2VgE-sIEACAUARgRAhwBRgQCAAASAJCIAJAiwQAAAiAQAAgARCIQAMDAILACwMAgABANAxRCgAECQgyICIpTAgKgSCA1sqEEoLpDTCAOssAKCRGxUACIJARWAAICwcAwRICViwQJMUb5ACMEKAUSoVqIAAAAA.YAAAAAAAAAAA"
-          },
-          { "name": "addtl_consent", "value": "1~" }
-        ]
-      },
+      "cookies": {},
       "id": "362b64e3-c12d-4d5e-9c8e-169df9782b28",
       "domains": ["ilgiornale.it"]
     },
     {
-      "click": {
-        "optIn": "button.w-button-primary",
-        "presence": "div.w-cookies-popup__footer"
+      "click": {},
+      "cookies": {
+        "optOut": [
+          {
+            "name": "CookieConsent",
+            "value": "{stamp:%27hLskZi6GtaCNeWwvKfJCnNdwijLGPiuqz0obMpsw2C4o6inSM80MLQ==%27%2Cnecessary:true%2Cpreferences:false%2Cstatistics:false%2Cmarketing:false%2Cmethod:%27explicit%27%2Cver:1%2Cutc:1675088694646%2Ciab2:%27CPmZlUAPmZlUACGABBENC1CgAAAAAAAAAAAAAAAAAAAA.YAAAAAAAAAAA%27%2Cgacm:%271~%27%2Cregion:%27ro%27}"
+          }
+        ]
       },
-      "cookies": {},
       "id": "905b5c20-000d-4b7b-a8d6-d84d2311dfdf",
       "domains": ["worten.pt"]
     },
@@ -2285,22 +2183,7 @@
         "optIn": "button.css-14ubilm",
         "presence": "div#qc-cmp2-container"
       },
-      "cookies": {
-        "optIn": [
-          {
-            "name": "cto_bundle",
-            "value": "okMPRV9sZXVYa2NJc2RnSzNMSFBZQ1k5RzBQNzVlZ0NRSDZaMFdoMmpEQmZ4S0dDcU9XMmxRckpkeGdwUlN2d0FSbDdZa280czY1enpUNlElMkZIaGdud0FwRDN3b1BlUElmJTJCVVNKa3NCaTFGa1RDR2FZbFBRS3dXWVpzN2x5bmRmYXZSZzlzUzQlMkYxOXRCNk5MMHdnMDVzNTRqQnclM0QlM0Q"
-          },
-          { "name": "gdpr_consent_v1", "value": "1:1,2:1,3:1,4:1" }
-        ],
-        "optOut": [
-          { "name": "addtl_consent", "value": "1~" },
-          {
-            "name": "euconsent-v2",
-            "value": "CPgyVIAPgyVIAAKAsBSVCkCgAAAAAH_AACQgAAASIAJMNW4gC7MscGbQMIoEQIwrCQqgUAEFAMLRAYAODgp2VgE-sIEACAUARgRAhwBRgQCAAASAJCIAJAiwQAAAiAQAAgARCIQAMDAILACwMAgABANAxRCgAECQgyICIpTAgKgSCA1sqEEoLpDTCAOssAKCRGxUACIJARWAAICwcAwRICViwQJMUb5ACMEKAUSoVqIAAAAA.YAAAAAAAAAAA"
-          }
-        ]
-      },
+      "cookies": {},
       "id": "deca4013-d55c-424b-9a46-2df8139fd415",
       "domains": ["tradera.com"]
     },
@@ -2348,16 +2231,7 @@
     },
     {
       "click": { "optIn": "a.cmptxt_btn_yes", "presence": "div.cmpboxbtns" },
-      "cookies": {
-        "optIn": [
-          {
-            "name": "cto_bundle",
-            "value": "PEQl-F9nY0JYMHZNdWU5U1BhNm41bXhXNTljSXFLeG1aV1I0S0hSQVI1WVRwZjhCaVZacUtTUFpjUCUyQkJhUUZmdE9ZYTVFRCUyRlR5WjJZbjlzeiUyRk0wWFZyd3lmSTAxWGRFeVVFUGpXYTdFdSUyRmJLTjglMkJDYWYwU05DN3B6JTJGOWFMcm13MUtSMQ"
-          },
-          { "name": "_pbjs_userid_consent_data", "value": "6346944235117479" }
-        ],
-        "optOut": []
-      },
+      "cookies": {},
       "id": "4dce4250-5d45-4cf8-bb0c-f485de812859",
       "domains": ["alo.rs"]
     },
@@ -2379,6 +2253,7 @@
       "cookies": {},
       "id": "1653780d-92d7-4677-acb0-6427a7bbdeba",
       "domains": [
+        "amazon.se",
         "amazon.fr",
         "amazon.nl",
         "amazon.es",
@@ -2393,13 +2268,6 @@
         "presence": "div.fc-footer-buttons-container"
       },
       "cookies": {
-        "optIn": [
-          {
-            "name": "FCNEC",
-            "value": "%5B%5B%22AKsRol-HZQOROXcWlEdDgZQEbUvxfST1zVzLuTo-8HJcZi_1x5knwF_j_x-Sy7iYJ421kbLwsAc_W_pDCXxMV8AkezlQ0Se4_psg1B28BVAo7Tv3RXdkyn1csYKRvnE5fjLug299zvFC3FsG3cPz5FSRf0qmXtp3HQ%3D%3D%22%5D%2Cnull%2C%5B%5D%5D"
-          },
-          { "name": "_pbjs_userid_consent_data", "value": "8477155220263717" }
-        ],
         "optOut": [
           {
             "name": "FCCDCF",
@@ -2425,26 +2293,17 @@
         "optIn": "button.css-mn27n0",
         "presence": "div.qc-cmp2-summary-buttons"
       },
-      "cookies": {
-        "optIn": [
-          {
-            "name": "euconsent-v2",
-            "value": "CPg_g4APg_g4AAKAsAPTClCsAP_AAH_AAB6YJFNd_H__bW9r-f5_aft0eY1P9_r37uQzDhfNk-8F3L_W_LwX52E7NF36tq4KmR4ku1LBIUNlHMHUDUmwaokVryHsak2cpzNKJ7BEknMZOydYGF9vmxtj-QKY7_5_d3bx2D-t_9v239z3z81Xn3d53-_03LCdV5_9Dfn9fR_bc9KPt_58v8v8_____3_e__3_7997BIgAkw1biALsyxwZtAwigRAjCsJCqBQAQUAwtEBgA4OCnZWAT6wgQAIBQBGBECHAFGBAIAABIAkIgAkCLBAAACIBAACABEIhAAwMAgsALAwCAAEA0DFEKAAQJCDIgIilMCAqBIIDWyoQSgukNMIA6ywAoJEbFQAIgkBFYAAgLBwDBEgJWLBAkxRvkAIwQoBRKhWogAAA.YAAAAAAAAAAA"
-          }
-        ],
-        "optOut": [{ "name": "addtl_consent", "value": "1~" }]
-      },
+      "cookies": {},
       "id": "c49fa28b-a67c-42b8-a4e5-4d48d34fba04",
       "domains": ["observador.pt"]
     },
     {
       "click": {
-        "optIn": "div.marginbottom15px",
-        "presence": "div.boton_cookies"
+        "optIn": "div.boton_cookies",
+        "presence": "div#popup_cookies"
       },
       "cookies": {
-        "optIn": [{ "name": "accept_cookies", "value": "ok" }],
-        "optOut": []
+        "optIn": [{ "name": "accept_cookies", "value": "ok" }]
       },
       "id": "60ea2eca-10af-47d1-a240-cbdf44519e9d",
       "domains": ["aemet.es"]
@@ -2475,25 +2334,7 @@
         "optIn": "button.css-k8o10q",
         "presence": "div#qc-cmp2-container"
       },
-      "cookies": {
-        "optIn": [
-          {
-            "name": "euconsent-v2",
-            "value": "CPhCz0APhCz0AAKAsAHUClCsAP_AAH_AAA6gJFNd_H__bW9r-f5_aft0eY1P9_r37mQzDhfNk-8F3L_W_LwX52E7NF36tq4KmR4Eu1LBIUNlHMHUDUmwaokVryHsak2cpzNKJ7BEknMZOydYGF9vmxtj-QKY7_5_d3bx2D-t_9v239T3z81Xn3d53-_03LCdV5_9Dfn9fR_bc9KPt_58v8v8_____3_e__3_7997BIgAkw1biALsyxwJtAwigRAjCsJCqAQAQUAwtEBgA4OCnZWAT6wgQAIBQBGBECHAFGBAIAABIAgIgAkCDBAAACIBAACABEIhAAwIAgoALAwCAAEA0DFEKAAQBCDIgIiFMCAqBIIDWyoQSgmgNMIAKywAoJAbAAAIgkBFYAAgLBgBBEgJGLBAkxRvkAIwQoBRKhWogAAA.YAAAAAAAAAAA"
-          },
-          {
-            "name": "cto_bundle",
-            "value": "C_6Ty19zTWdWemQ0N2RPUW9XUGNXRngyblVOUUxhbUVYZG1QNVclMkZmWjZ2d3MlMkY4Q3F4VlMzcEFocUhZd2tmUm1uMHUlMkJYT292JTJGM2x1eUZxUHFJYm1icDhnaTJVRmxYUWx4VGZ6YU9rTGNDR25JRmpiR2JLT0ZrWWZtd1BLOEslMkJFN2hadkY"
-          }
-        ],
-        "optOut": [
-          {
-            "name": "euconsent-v2",
-            "value": "CPhCz0APhCz0AAKAsBHUClCgAAAAAH_AAA6gAAASIAJMNW4gC7MscCbQMIoEQIwrCQqgEAEFAMLRAYAODgp2VgE-sIEACAUARgRAhwBRgQCAAASAICIAJAgwQAAAiAQAAgARCIQAMCAIKACwMAgABANAxRCgAEAQgyICIhTAgKgSCA1sqEEoJoDTCACssAKCQGwAACIJARWAAICwYAQRICRiwQJMUb5ACMEKAUSoVqIAAAAA.YAAAAAAAAAAA"
-          },
-          { "name": "addtl_consent", "value": "1~" }
-        ]
-      },
+      "cookies": {},
       "id": "2b12c85e-4ec0-4a3d-9cbe-9892db3f5850",
       "domains": ["napi.hu"]
     },
@@ -2512,16 +2353,6 @@
         "presence": "div.fc-footer-buttons"
       },
       "cookies": {
-        "optIn": [
-          {
-            "name": "FCNEC",
-            "value": "%5B%5B%22AKsRol-SmWE1Zek3oSjihDZo_-sHfz0GVCafvp0zkCi5H2GMAE9xpuf_zkiAxQgzVp1PIBRWGBeeXqkkHwMHRtU1r0lgkddKYGQavJ28LUIDiLAF3hu1JFxIhvMx4JWdlZVA_tAWcGch87e4lJtEv8_p4KkbeaOTGA%3D%3D%22%5D%2Cnull%2C%5B%5D%5D"
-          },
-          {
-            "name": "FCCDCF",
-            "value": "%5Bnull%2Cnull%2Cnull%2C%5B%22CPhCz0APhCz0AEsABBFIClCoAP_AAG_AAApAHQpB7D7FbSFCyP55aLsAMAhXRkCEQqQAAASBAmABQAKQIAQCkkAQFASgBAACAAAgIAJBAQIMCAgACUABQAAAAAEEAAAABAAIIAAAgAEAAAAIAAACAIAAEAAIAAAAEAAAmQhAAIIACAAABAAAAAAAAAAAAAAAAgdCgHsLsVtIUJI_GkoswAgCFdGQIRCoAAAAIECQAAAApAgBAKQQBAABKAEAAAAACAgAgEBAAgACAABQAFAAAAAAAAAAAAAAAggAACAAQAAAAAAAAIAgAAQAAgAAAAAAACJCEAAggAIAAAAAAAAAAAAAAAAAAACAAA.f_gAAAAAAAA%22%2C%221~2072.70.89.93.108.122.149.2202.162.167.196.2253.241.2299.259.2357.311.317.323.2373.338.358.2415.415.449.2506.2526.482.486.494.495.2568.2571.2575.540.574.2624.624.2677.817.827.864.981.1048.1051.1095.1097.1127.1171.1201.1205.1211.1276.1301.1365.1415.1449.1570.1577.1651.1716.1753.1765.1870.1878.1889.1958.2012%22%2C%22F4040C3F-B311-403C-9BDB-2AEA533CCD8D%22%5D%2Cnull%2Cnull%2C%5B%5D%5D"
-          }
-        ],
         "optOut": [
           {
             "name": "FCCDCF",
@@ -2537,30 +2368,15 @@
         "optIn": "button.css-k8o10q",
         "presence": "div#qc-cmp2-container"
       },
-      "cookies": {
-        "optIn": [
-          {
-            "name": "euconsent-v2",
-            "value": "CPhCz0APhCz0AAKAsAELClCsAP_AAH_AAAyIJFNd_H__bW9r-f5_aft0eY1P9_r37uQzDhfNk-8F3L_W_LwX52E7NF36tq4KmR4ku1LBIUNlHMHUDUmwaokVryHsak2cpzNKJ7BEknMZOydYGF9vmxtj-QKY7_5_d3bx2D-t_9v239z3z81Xn3d53-_03LCdV5_9Dfn9fR_bc9KPt_58v8v8_____3_e__3_7997BIgAkw1biALsyxwZtAwigRAjCsJCqBQAQUAwtEBgA4OCnZWAT6wgQAIBQBGBECHAFGBAIAABIAkIgAkCLBAAACIBAACABEIhAAwMAgsALAwCAAEA0DFEKAAQJCDIgIilMCAqBIIDWyoQSgukNMIA6ywAoJEbFQAIgkBFYAAgLBwDBEgJWLBAkxRvkAIwQoBRKhWogAAA.d_gACAAAAAAA"
-          },
-          { "name": "_pbjs_userid_consent_data", "value": "3497678886241208" }
-        ],
-        "optOut": [
-          {
-            "name": "euconsent-v2",
-            "value": "CPhCz0APhCz0AAKAsAELClCgAAAAAH_AAAyIAAASIAJMNW4gC7MscGbQMIoEQIwrCQqgUAEFAMLRAYAODgp2VgE-sIEACAUARgRAhwBRgQCAAASAJCIAJAiwQAAAiAQAAgARCIQAMDAILACwMAgABANAxRCgAECQgyICIpTAgKgSCA1sqEEoLpDTCAOssAKCRGxUACIJARWAAICwcAwRICViwQJMUb5ACMEKAUSoVqIAAAAA.YAAACAAAAAAA"
-          },
-          { "name": "addtl_consent", "value": "1~" }
-        ]
-      },
+      "cookies": {},
       "id": "ba9c17cd-19aa-4fe3-ac0c-9c3055133c5b",
       "domains": ["gossip-tv.gr"]
     },
     {
       "click": {
         "optIn": "button#pt-accept-all",
-        "optOut": "button.pt-tc4",
-        "presence": "div.pt-rAv"
+        "optOut": "div#pt-close",
+        "presence": "div#pubtech-cmp"
       },
       "cookies": {},
       "id": "531d8b09-8fce-4019-9f96-31d5add26a43",
@@ -2571,25 +2387,7 @@
         "optIn": "button.css-19ukivv",
         "presence": "div#qc-cmp2-container"
       },
-      "cookies": {
-        "optIn": [
-          {
-            "name": "cto_bundle",
-            "value": "Yipool9EenpScHBFMXp3Tlpjd0xocWxPY2tWRjhSWWxlSmIyQTRDRzIxJTJCcExaaEVBNk03TFVLaUQlMkZWd3h5JTJCOWpkVDdRQVBRMzJxVFo3cTRWaWQyNXk2cHk1NWZvY2tvUm10TFlHNmZCWiUyRnglMkZhJTJCOFBYTCUyRms2c3MxT0NhV0xFZ2phSlo5"
-          },
-          {
-            "name": "cto_bidid",
-            "value": "xajN-19yWFJNYjhCSXBUV2hxb0RyTVdMb2ZWSXVZYXhqQXQxMkpwa3ZpSUZGYm5sTjBZOEJJVFluSTlkMyUyRk9GcEdPejd3V29QdFNEZGttb1ZKa3klMkJUQWt5U2clM0QlM0Q"
-          }
-        ],
-        "optOut": [
-          {
-            "name": "euconsent-v2",
-            "value": "CPhCz0APhCz0AAKAsDNLClCgAAAAAAAAABpYAAASIgFAA4ACWAZ8BHgCVwGCAO2AdyA8ECRAAAAA.YAAAAAAAAAAA"
-          },
-          { "name": "addtl_consent", "value": "1~" }
-        ]
-      },
+      "cookies": {},
       "id": "5026561f-ffec-437e-bad8-820ac9d55659",
       "domains": ["vi.nl"]
     },
@@ -2599,12 +2397,6 @@
         "presence": "div.fc-footer-buttons"
       },
       "cookies": {
-        "optIn": [
-          {
-            "name": "cto_bundle",
-            "value": "F_Fs9V9HMWx0JTJCVk1oVGROWkZ1SFUlMkY5N2l6byUyQm9wNmd5bjZBY0EwYTdFcVplZnpYUnQwc2VkRThSQ3N0NUNWRW5NbUtickRXZlQyJTJGMzJHcXRoUnltRjJEdmgzJTJCRkxWQ2FBWngxcDNCVzFvZHpMYUREVHlUdGs2STFnM1JOUzVCZXNOZXA"
-          }
-        ],
         "optOut": [
           {
             "name": "FCCDCF",
@@ -2620,22 +2412,7 @@
         "optIn": "button.css-k8o10q",
         "presence": "div#qc-cmp2-container"
       },
-      "cookies": {
-        "optIn": [
-          { "name": "_pbjs_userid_consent_data", "value": "3524755945110770" },
-          {
-            "name": "euconsent-v2",
-            "value": "CPhGGwAPhGGwAAKAsAELClCsAP_AAH_AAAyIJFNd_H__bW9r-f5_aft0eY1P9_r37uQzDhfNk-8F3L_W_LwX52E7NF36tq4KmR4ku1LBIUNlHMHUDUmwaokVryHsak2cpzNKJ7BEknMZOydYGF9vmxtj-QKY7_5_d3bx2D-t_9v239z3z81Xn3d53-_03LCdV5_9Dfn9fR_bc9KPt_58v8v8_____3_e__3_7997BIgAkw1biALsyxwZtAwigRAjCsJCqBQAQUAwtEBgA4OCnZWAT6wgQAIBQBGBECHAFGBAIAABIAkIgAkCLBAAACIBAACABEIhAAwMAgsALAwCAAEA0DFEKAAQJCDIgIilMCAqBIIDWyoQSgukNMIA6ywAoJEbFQAIgkBFYAAgLBwDBEgJWLBAkxRvkAIwQoBRKhWogAAA.YAAAAAAAAAAA"
-          }
-        ],
-        "optOut": [
-          { "name": "_pbjs_userid_consent_data", "value": "3524755945110770" },
-          {
-            "name": "euconsent-v2",
-            "value": "CPhGGwAPhGGwAAKAsAELClCgAAAAAH_AAAyIAAASIAJMNW4gC7MscGbQMIoEQIwrCQqgUAEFAMLRAYAODgp2VgE-sIEACAUARgRAhwBRgQCAAASAJCIAJAiwQAAAiAQAAgARCIQAMDAILACwMAgABANAxRCgAECQgyICIpTAgKgSCA1sqEEoLpDTCAOssAKCRGxUACIJARWAAICwcAwRICViwQJMUb5ACMEKAUSoVqIAAAAA.YAAAAAAAAAAA"
-          }
-        ]
-      },
+      "cookies": {},
       "id": "0587a3cf-e084-40bf-b01a-2586c2313f3b",
       "domains": ["zougla.gr"]
     },
@@ -2644,27 +2421,16 @@
         "optIn": "button.css-1al1vdb",
         "presence": "div#qc-cmp2-container"
       },
-      "cookies": {
-        "optOut": [
-          {
-            "name": "euconsent-v2",
-            "value": "CPhGGwAPhGGwAAKAsBITClCgAAAAAH_AABCYAAASIAJMNW4gC7MscGbQMIoEQIwrCQqgUAEFAMLRAYAODgp2VgE-sIEACAUARgRAhwBRgQCAAASAJCIAJAiwQAAAiAQAAgARCIQAMDAILACwMAgABANAxRCgAECQgyICIpTAgKgSCA1sqEEoLpDTCAOssAKCRGxUACIJARWAAICwcAwRICViwQJMUb5ACMEKAUSoVqIAAAAA.YAAAAAAAAAAA"
-          },
-          { "name": "addtl_consent", "value": "1~" }
-        ]
-      },
+      "cookies": {},
       "id": "68c6fe41-fb1d-41ed-a8c6-55fde975f0ab",
       "domains": ["calciomercato.com"]
     },
     {
       "click": {
         "optIn": "a#consent_prompt_submit",
-        "presence": "div.global-overlay-content"
+        "presence": "div#__tealiumGDPRecModal"
       },
       "cookies": {
-        "optIn": [
-          { "name": "CONSENTMGR", "value": "consent:true%7Cts:1666183380115" }
-        ],
         "optOut": [
           {
             "name": "CONSENTMGR",
@@ -2686,18 +2452,7 @@
         "optIn": "button#accept-privacy-policies",
         "presence": "div.emb38ba0"
       },
-      "cookies": {
-        "optIn": [
-          {
-            "name": "s_sq",
-            "value": "wmicanadaprod%3D%2526c.%2526a.%2526activitymap.%2526page%253DHome%252520Page%2526link%253DClose%2526region%253DBODY%2526pageIDType%253D1%2526.activitymap%2526.a%2526.c%2526pid%253DHome%252520Page%2526pidt%253D1%2526oid%253Dfunctiongr%252528%252529%25257B%25257D%2526oidt%253D2%2526ot%253DSUBMIT"
-          },
-          {
-            "name": "wmicanadaprod%3D%2526c.%2526a.%2526activitymap.%2526page%253DHome%252520Page%2526link%253DClose%2526region%253DBODY%2526pageIDType%253D1%2526.activitymap%2526.a%2526.c%2526pid%253DHome%252520Page%2526pidt%253D1%2526oid%253Dfunctiongr%252528%252529%25257B%25257D%2526oidt%253D2%2526ot%253DSUBMIT",
-            "value": "true"
-          }
-        ]
-      },
+      "cookies": {},
       "id": "0485cf43-5df0-41aa-83da-92cd3b82d6f7",
       "domains": ["walmart.ca"]
     },
@@ -2716,21 +2471,7 @@
         "optIn": "button.css-1hzdrx2",
         "presence": "div.qc-cmp2-summary-buttons"
       },
-      "cookies": {
-        "optIn": [
-          {
-            "name": "cto_bundle",
-            "value": "hRwg-F9hazQ4NWh4Q2VZQURIZEdKVUVBMXNpcDZxMk9IejdiN3BNUnJ5TWtrMGtQOTZVWEl6ZktQcDlmMDZuQkhhczVQc0xwcEFVenFxSmF5czFJakU0V1dabzZVOSUyQjd6ZzZwUmhxS3pkYUMlMkZSSW1JcTRFWk1jJTJGYjFaN1pEWlduM1Vkeg"
-          }
-        ],
-        "optOut": [
-          { "name": "addtl_consent", "value": "1~" },
-          {
-            "name": "euconsent-v2",
-            "value": "CPhGGwAPhGGwAAKAsAELClCgAAAAAH_AAAyIAAASIAJMNW4gC7MscGbQMIoEQIwrCQqgUAEFAMLRAYAODgp2VgE-sIEACAUARgRAhwBRgQCAAASAJCIAJAiwQAAAiAQAAgARCIQAMDAILACwMAgABANAxRCgAECQgyICIpTAgKgSCA1sqEEoLpDTCAOssAKCRGxUACIJARWAAICwcAwRICViwQJMUb5ACMEKAUSoVqIAAAAA.YAAAAAAAAAAA"
-          }
-        ]
-      },
+      "cookies": {},
       "id": "b9fd5871-876d-4931-9f76-dd695e613919",
       "domains": ["newsbeast.gr"]
     },
@@ -2749,45 +2490,25 @@
         "optIn": "button.rodo-popup-agree",
         "presence": "div.rodo-popup-buttons"
       },
-      "cookies": {
-        "optIn": [
-          { "name": "_pbjs_userid_consent_data", "value": "3977206233479728" },
-          {
-            "name": "cto_bundle",
-            "value": "SFc7jV9Eb0pLaEdqTEtEOHFGMjdDJTJGYzJsdHJnSW1DdnV1ZWQ3ZmJ1QWlQYVlBUGFUcTAycjJ1UHpmQjA3eUxnZHM3Uk1kVWlmVXgxWmlzakt6b1hJcUUzcHFrb2RvcCUyRnh6WldmY0UxQjJIcXJDdmdLZCUyRnZHZlQ1eFpKeEZmemNidnRYdXgxQXRVTiUyRjZQZ0dleGRydFdvVUlCZyUzRCUzRA"
-          }
-        ],
-        "optOut": [
-          { "name": "_pbjs_userid_consent_data", "value": "5610641117693523" }
-        ]
-      },
+      "cookies": {},
       "id": "397fdd1a-d6b7-4bab-a105-3f1f36f755ff",
       "domains": ["pomponik.pl"]
     },
     {
       "click": {
-        "optIn": "button.aza-cta-button",
+        "optIn": "button.accept-cookie-button",
         "presence": "div.cookie-banner-content"
       },
-      "cookies": {
-        "optIn": [
-          { "name": "AZACOOKIECONSENT_ANALYSIS", "value": "YES" },
-          { "name": "AZACOOKIECONSENT_MARKETING", "value": "YES" }
-        ],
-        "optOut": [
-          { "name": "AZACOOKIECONSENT_MARKETING", "value": "NO" },
-          { "name": "AZACOOKIECONSENT_ANALYSIS", "value": "NO" }
-        ]
-      },
+      "cookies": {},
       "id": "803fbd5e-3734-4cf6-a878-5ffe24ec6809",
       "domains": ["avanza.se"]
     },
     {
       "click": {
         "optIn": "button#consent_prompt_submit",
-        "presence": "div.ppm-cookie-banner__action"
+        "presence": "div#__tealiumGDPRecModal"
       },
-      "cookies": { "optIn": [{ "name": "consentprompt", "value": "yes" }] },
+      "cookies": {},
       "id": "c40f3982-0372-4cdd-8aea-c150afd8328e",
       "domains": ["post.ch"]
     },
@@ -2796,31 +2517,11 @@
         "optIn": "div.policy-accept",
         "presence": "div#privacy-policy-banner"
       },
-      "cookies": {},
+      "cookies": {
+        "optIn": [{ "name": ".AspNet.Consent", "value": "yes" }]
+      },
       "id": "60f526aa-abb2-4930-bec4-7113af7481ae",
       "domains": ["accuweather.com"]
-    },
-    {
-      "click": {
-        "optIn": "button.fc-button",
-        "presence": "div.fc-footer-buttons"
-      },
-      "cookies": {
-        "optIn": [
-          {
-            "name": "FCNEC",
-            "value": "%5B%5B%22AKsRol8n1sRGaWj3DZsGv3P802g_HWVWfo3HoGdhNOUoao4aMSxgdgJVoS4LbcPyZHMLABOdD-iYEJ5iOns-QN2TqE0Ib0lPXMkxrXlKAyu57IIoq4LZXE0I5oM5qKL46CxolQda4urPU1XllYEN28PcGgzMxE0Dtg%3D%3D%22%5D%2Cnull%2C%5B%5D%5D"
-          }
-        ],
-        "optOut": [
-          {
-            "name": "UA_ADS",
-            "value": "{\"/88449691,7691969/jedanklik.hr/home_970x250_v1\":4,\"/88449691,7691969/jedanklik.hr/home_970x250_v2\":5,\"/88449691,7691969/jedanklik.hr/home_970x250_v4\":5,\"/88449691,7691969/jedanklik.hr/content_v1\":5,\"/88449691,7691969/jedanklik.hr/content_v2\":5,\"/88449691,7691969/jedanklik.hr/content_v3\":5,\"/88449691,7691969/jedanklik.hr/content_v4\":5,\"/88449691,7691969/jedanklik.hr/content_v5\":5,\"/88449691,7691969/jedanklik.hr/home_300x250_v2\":4,\"/88449691,7691969/jedanklik.hr/home_300x250_v3\":4,\"/88449691,7691969/jedanklik.hr/home_300x250_v4\":5,\"/88449691,7691969/jedanklik.hr/banner_300x250_v1\":5,\"/88449691,7691969/jedanklik.hr/home_300x600_v1\":5,\"/88449691,7691969/jedanklik.hr/home_300x600_v2\":5,\"/88449691,7691969/jedanklik.hr/home_300x600_v3\":5,\"/88449691,7691969/jedanklik.hr/home_970x90_v1\":4,\"/88449691,7691969/jedanklik.hr/home_970x250_v3\":5,\"/88449691,7691969/jedanklik.hr/home_300x250_v5\":5}"
-          }
-        ]
-      },
-      "id": "da442430-1131-4e32-93c7-2c3710d723d1",
-      "domains": ["klik.hr"]
     },
     {
       "click": {
@@ -2852,40 +2553,9 @@
         "optIn": "button#didomi-notice-agree-button",
         "presence": "div#buttons"
       },
-      "cookies": {
-        "optIn": [
-          {
-            "name": "cto_bundle",
-            "value": "6aLX919zWVViT3VtakgxJTJCTkVEcmJ1TE5QV1VUWFhkVyUyQmo2RzlNek0lMkJ1QWJ3V3BpdHYlMkJsYk9reUVBeVBTUUNwUTE0MWFpRkZyd3BYNTZRJTJGSHcxMWZVVDc2T3AzSlpTdkVIQlFHUFE0b1piZnBGNEhrZWJsS0RKcHl5T0ZJSWo1ZHMzVTliY1RDUHRZU1gyUlpBbmVPVjdRNlBBJTNEJTNE"
-          }
-        ],
-        "optOut": [
-          {
-            "name": "euconsent-v2",
-            "value": "CPhJZsAPhJZsAAHABBENClCgAAAAAH_AAB6YAAASEAJMNW4gC7EscCbaMIoEQIwrCQ6gUAFFAMLRAYQOrgp2VwE-sIEACAUARgRAhwBRgwCAAACAJCIgJAjwQCAAiAQAAgAVCIQAEbAIKACwMAgAFANCxRigCECQgyICIpTAgIkSCgnsqEEoP9DTCEOssAKDR_xUICJQAhWBEJCwchwRICXiyQLMUb5ACMEKAUSoVqAA.YAAAD_gAAAAA"
-          }
-        ]
-      },
+      "cookies": {},
       "id": "1a37cced-b12a-44d9-a576-d1b259312471",
       "domains": ["zerozero.pt"]
-    },
-    {
-      "click": {
-        "optIn": "button.css-47sehv",
-        "presence": "div.qc-cmp2-summary-buttons"
-      },
-      "cookies": {
-        "optIn": [{ "name": "__qca", "value": "P0-1357318454-1666256367279" }],
-        "optOut": [
-          { "name": "addtl_consent", "value": "1~" },
-          {
-            "name": "euconsent-v2",
-            "value": "CPhJZsAPhJZsAAKAsBROClCgAAAAAH_AACJwAAASIAJMNW4gC7MscGbQMIoEQIwrCQqgUAEFAMLRAYAODgp2VgE-sIEACAUARgRAhwBRgQCAAASAJCIAJAiwQAAAiAQAAgARCIQAMDAILACwMAgABANAxRCgAECQgyICIpTAgKgSCA1sqEEoLpDTCAOssAKCRGxUACIJARWAAICwcAwRICViwQJMUb5ACMEKAUSoVqIAAAAA.YAAAAAAAAAAA"
-          }
-        ]
-      },
-      "id": "1b9d2d3b-484c-4654-8da5-a73497b2a206",
-      "domains": ["cancan.ro"]
     },
     {
       "click": {
@@ -2914,14 +2584,7 @@
         "optIn": "input.btn-secondary",
         "presence": "div.stampenCookieContainer"
       },
-      "cookies": {
-        "optIn": [
-          {
-            "name": "_pctx",
-            "value": "%7Bu%7DN4IgDghg5gpgagSxgdwJIBMQC4QBsCcUArgGwBGA1jALYBuAXkQCwBMAdgPYgA0IRAzjABO-bGyK5cvAcIDKAFwjyB2EBE5seIfgnkwMqgIyGAzCfyGAHExMBWQwAYbTSw9sB2EAF8gA"
-          }
-        ]
-      },
+      "cookies": {},
       "id": "e4e59ff1-b18c-453b-a4e0-6c0ec4008d81",
       "domains": ["gp.se"]
     },
@@ -2942,13 +2605,7 @@
         "presence": "div.cli-bar-container"
       },
       "cookies": {
-        "optIn": [
-          { "name": "viewed_cookie_policy", "value": "yes" },
-          {
-            "name": "CookieLawInfoConsent",
-            "value": "eyJuZWNlc3NhcnkiOnRydWUsImFuYWx5dGljcyI6dHJ1ZSwiYWR2ZXJ0aXNlbWVudCI6dHJ1ZSwib3RoZXJzIjp0cnVlLCJwZXJmb3JtYW5jZSI6dHJ1ZX0="
-          }
-        ]
+        "optIn": [{ "name": "viewed_cookie_policy", "value": "yes" }]
       },
       "id": "caddc16b-c8ad-404a-bd29-6383977695cb",
       "domains": ["katalozi.net"]
@@ -2959,13 +2616,9 @@
         "presence": "div.legal-consent"
       },
       "cookies": {
-        "optIn": [
-          { "name": "mal_consent_gdpr_remarketing", "value": "t" },
-          { "name": "mal_consent_gdpr_personalization", "value": "t" }
-        ],
         "optOut": [
           { "name": "mal_consent_gdpr_remarketing", "value": "f" },
-          { "name": "mal_consent_gdpr_personalization", "value": "1" }
+          { "name": "mal_consent_gdpr_personalization", "value": "f" }
         ]
       },
       "id": "6bc9ceec-b225-4284-b924-589c3ff4f249",
@@ -2975,7 +2628,7 @@
       "click": {
         "optIn": "a.wscrOk",
         "optOut": "a.wscrOk2",
-        "presence": "div.wscrBannerContent"
+        "presence": "div#CookieReportsPanel"
       },
       "cookies": {},
       "id": "cf282f72-5333-48a8-9097-cbc89ea26634",
@@ -2996,7 +2649,6 @@
         "presence": "div#cookie-bar"
       },
       "cookies": {
-        "optIn": [{ "name": "_fbp", "value": "fb.1.1666257920980.1495539528" }],
         "optOut": [
           {
             "name": "CookiePermissionInfo",
@@ -3006,29 +2658,6 @@
       },
       "id": "e4a9e084-a37e-4f10-969c-c872f578dd15",
       "domains": ["postnl.nl"]
-    },
-    {
-      "click": {
-        "optIn": "button.css-47sehv",
-        "presence": "div#qc-cmp2-container"
-      },
-      "cookies": {
-        "optIn": [
-          {
-            "name": "__gfp_64b",
-            "value": "nXC7yXo8aJ2dRZK6WNanPiTothNgalkp.W2jhtT2uzb.o7|1666265842"
-          }
-        ],
-        "optOut": [
-          { "name": "addtl_consent", "value": "1~" },
-          {
-            "name": "euconsent-v2",
-            "value": "CPhJZsAPhJZsAAKAsBROClCgAAAAAH_AACJwAAASIAJMNW4gC7MscGbQMIoEQIwrCQqgUAEFAMLRAYAODgp2VgE-sIEACAUARgRAhwBRgQCAAASAJCIAJAiwQAAAiAQAAgARCIQAMDAILACwMAgABANAxRCgAECQgyICIpTAgKgSCA1sqEEoLpDTCAOssAKCRGxUACIJARWAAICwcAwRICViwQJMUb5ACMEKAUSoVqIAAAAA.YAAAAAAAAAAA"
-          }
-        ]
-      },
-      "id": "ad724f2b-3721-4b6a-ac55-a52f14e26727",
-      "domains": ["evz.ro"]
     },
     {
       "click": {
@@ -3044,21 +2673,13 @@
       "click": {
         "optIn": "button.js_cookieBannerPermissionButton",
         "optOut": "span.js_cookieBannerProhibitionButton",
-        "presence": "div.cookieBanner__container"
+        "presence": "section#cookieBanner"
       },
-      "cookies": {},
+      "cookies": {
+        "optOut": [{ "name": "cb", "value": "0" }]
+      },
       "id": "c9adac7f-74db-4eab-9b97-114ff5954226",
       "domains": ["otto.de"]
-    },
-    {
-      "click": {
-        "optIn": "button#uc-btn-accept-banner",
-        "optOut": "button#uc-btn-deny-banner",
-        "presence": "div.uc-banner-content"
-      },
-      "cookies": {},
-      "id": "6a6864e3-dbfb-4fb7-b265-17a12231a11c",
-      "domains": ["zalando.be"]
     },
     {
       "click": {
@@ -3072,56 +2693,27 @@
     },
     {
       "click": {
-        "optIn": "button.pr-c9kuyn",
-        "optOut": "button.pr-1k13tj9",
+        "optIn": "button.pr-riqlv6",
+        "optOut": "button.pr-1l8klmj",
         "presence": "div#consent"
       },
-      "cookies": {},
+      "cookies": {
+        "optOut": [
+          { "name": "data_consent", "value": "1.1.0.0.0.1675177081479.Default" }
+        ]
+      },
       "id": "be039e17-f095-46f4-a809-c00699799db8",
       "domains": ["pricerunner.dk"]
     },
     {
-      "click": {
-        "optIn": "button.css-1lgi3ta",
-        "presence": "div#qc-cmp2-container"
-      },
-      "cookies": {
-        "optIn": [
-          {
-            "name": "euconsent-v2",
-            "value": "CPhJZsAPhJZsAAKAsAELClCsAP_AAH_AAAyIJFNd_H__bW9r-f5_aft0eY1P9_r37uQzDhfNk-8F3L_W_LwX52E7NF36tq4KmR4ku1LBIUNlHMHUDUmwaokVryHsak2cpzNKJ7BEknMZOydYGF9vmxtj-QKY7_5_d3bx2D-t_9v239z3z81Xn3d53-_03LCdV5_9Dfn9fR_bc9KPt_58v8v8_____3_e__3_7997BIgAkw1biALsyxwZtAwigRAjCsJCqBQAQUAwtEBgA4OCnZWAT6wgQAIBQBGBECHAFGBAIAABIAkIgAkCLBAAACIBAACABEIhAAwMAgsALAwCAAEA0DFEKAAQJCDIgIilMCAqBIIDWyoQSgukNMIA6ywAoJEbFQAIgkBFYAAgLBwDBEgJWLBAkxRvkAIwQoBRKhWogAAA.f_gAAAAAAAAA"
-          }
-        ],
-        "optOut": [
-          {
-            "name": "euconsent-v2",
-            "value": "CPhJZsAPhJZsAAKAsAELClCgAAAAAH_AAAyIAAASIAJMNW4gC7MscGbQMIoEQIwrCQqgUAEFAMLRAYAODgp2VgE-sIEACAUARgRAhwBRgQCAAASAJCIAJAiwQAAAiAQAAgARCIQAMDAILACwMAgABANAxRCgAECQgyICIpTAgKgSCA1sqEEoLpDTCAOssAKCRGxUACIJARWAAICwcAwRICViwQJMUb5ACMEKAUSoVqIAAAAA.YAAAAAAAAAAA"
-          },
-          { "name": "addtl_consent", "value": "1~" }
-        ]
-      },
-      "id": "d5bfd040-a445-44f4-9773-fb7cf19cff79",
-      "domains": ["makeleio.gr"]
-    },
-    {
       "click": { "optIn": "div.tvp-covl__ab", "presence": "div#ip" },
-      "cookies": {
-        "optIn": [
-          {
-            "name": "TVPtcs2",
-            "value": "CPhOZ67PhOZ67FfACAENCmCsAP_AAH_AAB5YJFNd_H__bW9r-f5_aft0eY1P9_r37uQzDhfNk-8F3L_W_LwX52E7NF36tq4KmR4ku1LBIUNlHMHUDUmwaokVryHsak2cpzNKJ7BEknMZOydYGF9vmxtj-QKY7_5_d3bx2D-t_9v239z3z81Xn3d53-_03LCdV5_9Dfn9fR_bc9KPt_58v8v8_____3_e__3_7997BIQAkw1biALsSxwJtAwigRAjCsJCqBQAQUAwtEBgA4OCnZWAT6wgQAIBQBGBECHAFGBAIAAAIAkIgAkCLBAAACIBAACABEIhAAQMAgoALAwCAAEA0DFEKAAQJCDIgIilMCAiBIICWyoQSgukNMIA6ywAoJEbFQAIgAAFYAAgLBwDBEgJWLBAkxRvkAIwQoBRKhWoAAAA.f_gAAAAABX_gAAAA"
-          }
-        ],
-        "optOut": [{ "name": "TVPtcs2ver", "value": "166" }]
-      },
+      "cookies": {},
       "id": "fb333123-4f00-4b45-acf9-21cb038c76ba",
       "domains": ["tvp.pl"]
     },
     {
       "click": { "optIn": "button.css-1g5s5vy", "presence": "div#qc-cmp2-ui" },
-      "cookies": {
-        "optIn": [{ "name": "_gcl_au", "value": "1.1.728794945.1666355472" }]
-      },
+      "cookies": {},
       "id": "992a91e5-9d29-411a-a8e6-e689fb75c2b7",
       "domains": ["meo.pt"]
     },
@@ -3175,7 +2767,7 @@
         "optIn": "button#consent_prompt_submit",
         "presence": "div.consent_prompt_footer"
       },
-      "cookies": { "optIn": [{ "name": "_tt_enable_cookie", "value": "1" }] },
+      "cookies": {},
       "id": "88e79126-8072-4079-aa60-1d71d9ddb65b",
       "domains": ["argos.co.uk"]
     },
@@ -3213,19 +2805,13 @@
         "optIn": "button.iubenda-cs-accept-btn",
         "presence": "div#iubenda-cs-banner"
       },
-      "cookies": {
-        "optIn": [{ "name": "wt_cookiecontrol", "value": "1" }],
-        "optOut": []
-      },
+      "cookies": {},
       "id": "c839d2c3-ee29-4015-a990-8cfe9884a4c4",
       "domains": ["ilmessaggero.it"]
     },
     {
       "click": { "optIn": "button#btn-agree-all", "presence": "div#rgpd" },
-      "cookies": {
-        "optIn": [{ "name": "rtp_cookie_privacy", "value": "permit 1,2,3,4" }],
-        "optOut": [{ "name": "rtp_cookie_privacy", "value": "permit 1" }]
-      },
+      "cookies": {},
       "id": "46e07f9b-9ce4-4fea-8be7-48a089bdb8d0",
       "domains": ["rtp.pt"]
     },
@@ -3234,7 +2820,9 @@
         "optIn": "span.inline-block",
         "presence": "div#notice-cookie-block"
       },
-      "cookies": {},
+      "cookies": {
+        "optIn": [{ "name": "user_allowed_save_cookie", "value": "true" }]
+      },
       "id": "32139cbb-7e13-4cec-ba54-7bfb4f46277c",
       "domains": ["altex.ro"]
     },
@@ -3253,10 +2841,7 @@
         "optIn": "button.css-v43ltw",
         "presence": "div#qc-cmp2-container"
       },
-      "cookies": {
-        "optIn": [{ "name": "__qca", "value": "P0-424258902-1666593718210" }],
-        "optOut": [{ "name": "addtl_consent", "value": "1~" }]
-      },
+      "cookies": {},
       "id": "ef8548ec-5dd9-4201-a075-a32893f09953",
       "domains": ["filmaffinity.com"]
     },
@@ -3277,18 +2862,6 @@
     },
     {
       "click": {
-        "optIn": "button.css-k8o10q",
-        "presence": "div#qc-cmp2-container"
-      },
-      "cookies": {
-        "optIn": [{ "name": "__qca", "value": "P0-1486589523-1666599429500" }],
-        "optOut": [{ "name": "addtl_consent", "value": "1~" }]
-      },
-      "id": "3c238b3e-0046-44f3-8d6a-1d22f65ba868",
-      "domains": ["vrisko.gr"]
-    },
-    {
-      "click": {
         "optIn": "button.fc-cta-consent",
         "presence": "div.fc-dialog-container"
       },
@@ -3299,7 +2872,8 @@
         "fanatik.ro",
         "net.hr",
         "freemail.hu",
-        "marica.bg"
+        "marica.bg",
+        "dn.pt"
       ]
     },
     {
@@ -3317,9 +2891,18 @@
         "optIn": "button.css-47sehv",
         "presence": "div#qc-cmp2-container"
       },
-      "cookies": { "optOut": [{ "name": "addtl_consent", "value": "1~" }] },
+      "cookies": {},
       "id": "5a3bf87a-62c2-40b2-bfbb-b2dcf8c23f84",
-      "domains": ["dn.pt", "timeanddate.com", "livescience.com"]
+      "domains": [
+        "timeanddate.com",
+        "livescience.com",
+        "cancan.ro",
+        "evz.ro",
+        "gandul.ro",
+        "kurir.rs",
+        "capital.ro",
+        "techradar.com"
+      ]
     },
     {
       "click": {
@@ -3336,12 +2919,7 @@
         "optIn": "button#kc-acceptAndHide",
         "presence": "div#kconsent"
       },
-      "cookies": {
-        "optIn": [
-          { "name": "_hjFirstSeen", "value": "1" },
-          { "name": "_hjAbsoluteSessionInProgress", "value": "1" }
-        ]
-      },
+      "cookies": {},
       "id": "282ff551-ce28-4b7f-9633-eaaa7ce89890",
       "domains": ["k-ruoka.fi"]
     },
@@ -3360,27 +2938,9 @@
         "optIn": "button.css-fz9f1h",
         "presence": "div#qc-cmp2-container"
       },
-      "cookies": {
-        "optIn": [{ "name": "__qca", "value": "P0-1708252764-1666604453009" }],
-        "optOut": [
-          { "name": "addtl_consent", "value": "1~" },
-          { "name": "Exitbee_visitsCount", "value": "1" }
-        ]
-      },
+      "cookies": {},
       "id": "1c742d88-b3a7-43da-b205-3ba4afd92e63",
       "domains": ["dikaiologitika.gr"]
-    },
-    {
-      "click": {
-        "optIn": "button.css-k8o10q",
-        "presence": "div#qc-cmp2-container"
-      },
-      "cookies": {
-        "optIn": [{ "name": "__qca", "value": "P0-1491353199-1666610397815" }],
-        "optOut": [{ "name": "addtl_consent", "value": "1~" }]
-      },
-      "id": "45ce49b9-71c7-4800-9901-908f8d76807e",
-      "domains": ["fantacalcio.it"]
     },
     {
       "click": {
@@ -3393,13 +2953,7 @@
     },
     {
       "click": { "optIn": "button.css-tzlaik", "presence": "div#qc-cmp2-ui" },
-      "cookies": {
-        "optIn": [{ "name": "__qca", "value": "P0-254962009-1666612455195" }],
-        "optOut": [
-          { "name": "addtl_consent", "value": "1~" },
-          { "name": "_gat_nitfm", "value": "1" }
-        ]
-      },
+      "cookies": {},
       "id": "30542b9b-2225-4c22-bbd9-0e9d8f6273df",
       "domains": ["nit.pt"]
     },
@@ -3448,10 +3002,6 @@
         "presence": "div.cookies-buttons"
       },
       "cookies": {
-        "optIn": [
-          { "name": "cookiesPolicy", "value": "11111" },
-          { "name": "_tt_enable_cookie", "value": "1" }
-        ],
         "optOut": [{ "name": "cookiesPolicy", "value": "10000" }]
       },
       "id": "90b22cfd-00a8-4467-9334-96773066c2c1",
@@ -3479,10 +3029,7 @@
         "optIn": "button.css-1lgi3ta",
         "presence": "div#qc-cmp2-container"
       },
-      "cookies": {
-        "optIn": [],
-        "optOut": [{ "name": "addtl_consent", "value": "1~" }]
-      },
+      "cookies": {},
       "id": "570920f9-6a8a-4a26-a68a-8fc773ba30a9",
       "domains": ["ethnos.gr"]
     },
@@ -3491,7 +3038,7 @@
         "optIn": "button#CybotCookiebotDialogBodyLevelButtonLevelOptinAllowAll",
         "presence": "div#CybotCookiebotDialog"
       },
-      "cookies": { "optIn": [{ "name": "_tt_enable_cookie", "value": "1" }] },
+      "cookies": {},
       "id": "009f2741-56cb-485e-af5c-3102f8e9cf55",
       "domains": ["ingatlan.com"]
     },
@@ -3500,10 +3047,7 @@
         "optOut": "button.css-2y11ar",
         "presence": "div#qc-cmp2-container"
       },
-      "cookies": {
-        "optIn": [{ "name": "_dfm", "value": "true" }],
-        "optOut": [{ "name": "addtl_consent", "value": "1~" }]
-      },
+      "cookies": {},
       "id": "794449a7-94aa-402a-a32c-3859bec7eff8",
       "domains": ["dagospia.com"]
     },
@@ -3515,15 +3059,6 @@
       "cookies": {},
       "id": "1779bdc8-3544-4a2f-ba38-026f6533d665",
       "domains": ["finansavisen.no"]
-    },
-    {
-      "click": { "optIn": "button.css-47sehv", "presence": "div#qc-cmp2-ui" },
-      "cookies": {
-        "optIn": [],
-        "optOut": [{ "name": "addtl_consent", "value": "1~" }]
-      },
-      "id": "9dc8b12d-5751-4d6f-9f06-f7d537f92971",
-      "domains": ["gandul.ro"]
     },
     {
       "click": {
@@ -3543,7 +3078,7 @@
         "optIn": "button.jad_cmp_paywall_button-cookies",
         "presence": "div#didomi-host"
       },
-      "cookies": { "optIn": [{ "name": "fidcsnt", "value": "1" }] },
+      "cookies": {},
       "id": "b933bc7f-27b7-44a7-9127-66f98c93ea8f",
       "domains": ["purepeople.com"]
     },
@@ -3552,10 +3087,7 @@
         "optIn": "button.css-1euwp1t",
         "presence": "div#qc-cmp2-container"
       },
-      "cookies": {
-        "optIn": [],
-        "optOut": [{ "name": "addtl_consent", "value": "1~" }]
-      },
+      "cookies": {},
       "id": "20e1f1c3-0914-42b4-9022-3ce80b79a480",
       "domains": ["enikos.gr"]
     },
@@ -3580,7 +3112,7 @@
       },
       "cookies": {},
       "id": "3203ac4e-2454-4022-90fb-d4f51467ce20",
-      "domains": ["zalando.ch"]
+      "domains": ["zalando.ch", "zalando.dk", "zalando.be"]
     },
     {
       "click": { "optIn": "a.cookies-agree", "presence": "div.cookies-notify" },
@@ -3593,10 +3125,7 @@
         "optIn": "button.css-1xqnplm",
         "presence": "div#qc-cmp2-container"
       },
-      "cookies": {
-        "optIn": [],
-        "optOut": [{ "name": "addtl_consent", "value": "1~" }]
-      },
+      "cookies": {},
       "id": "4f86f2e9-ea7f-4ee7-a4d2-b2253a5f1c1d",
       "domains": ["lifo.gr"]
     },
@@ -3626,24 +3155,9 @@
         "optIn": "button.css-hxv78t",
         "presence": "div#qc-cmp2-container"
       },
-      "cookies": {
-        "optIn": [{ "name": "_tt_enable_cookie", "value": "1" }],
-        "optOut": [{ "name": "addtl_consent", "value": "1~" }]
-      },
+      "cookies": {},
       "id": "5a256bf7-29a7-485e-8305-fcafd7a52af9",
       "domains": ["rsvplive.ie"]
-    },
-    {
-      "click": {
-        "optIn": "button.css-47sehv",
-        "presence": "div#qc-cmp2-container"
-      },
-      "cookies": {
-        "optIn": [],
-        "optOut": [{ "name": "addtl_consent", "value": "1~" }]
-      },
-      "id": "936d0cd7-2c7b-4d43-92bf-0cffce92d51e",
-      "domains": ["capital.ro", "techradar.com"]
     },
     {
       "click": { "optIn": "a.cc-dismiss", "presence": "div.cc-compliance" },
@@ -3664,7 +3178,7 @@
     },
     {
       "click": { "optIn": "a.close-accept", "presence": "div.woahbar" },
-      "cookies": { "optIn": [{ "name": "pelm_cstate", "value": "closed" }] },
+      "cookies": {},
       "id": "8e772dc2-be57-4cf6-ad51-574b2accf86c",
       "domains": ["meteomedia.com"]
     },
@@ -3682,6 +3196,7 @@
         "gofundme.com",
         "frontiersin.org",
         "espncricinfo.com",
+        "espn.com",
         "thawte.com",
         "digicert.com"
       ]
@@ -3714,16 +3229,6 @@
       },
       "id": "befe1d72-f33a-4e63-be43-236bedc3b49a",
       "domains": ["milenio.com"]
-    },
-    {
-      "click": {
-        "optIn": "button#uc-btn-accept-banner",
-        "optOut": "button#uc-btn-deny-banner",
-        "presence": "div#uc-main-banner"
-      },
-      "cookies": {},
-      "id": "45ab789b-8f8b-4112-a56f-aa3035f15acf",
-      "domains": ["zalando.dk"]
     },
     {
       "click": {
@@ -4713,7 +4218,6 @@
         "okdiario.com",
         "dhnet.be",
         "lecturas.com",
-        "hasznaltauto.hu",
         "elperiodico.com",
         "dumpert.nl"
       ]
@@ -4831,15 +4335,6 @@
       "domains": ["sapo.pt"]
     },
     {
-      "click": {
-        "optIn": "button.cmp-intro_acceptAll",
-        "presence": "div.cmp-popup_popup"
-      },
-      "cookies": {},
-      "id": "2406241a-c4ec-4aac-a4ee-ed20a62d27e1",
-      "domains": ["blick.ch"]
-    },
-    {
       "click": {},
       "cookies": {
         "optOut": [
@@ -4869,15 +4364,6 @@
       "cookies": {},
       "id": "aeff05cc-c287-4596-89b6-3559eced1133",
       "domains": ["iefimerida.gr"]
-    },
-    {
-      "click": {
-        "optIn": "button.css-1tfx6ee",
-        "presence": "div#qc-cmp2-container"
-      },
-      "cookies": {},
-      "id": "ed151d82-aea4-407e-9ab3-d83dad4a0b14",
-      "domains": ["24.hu"]
     },
     {
       "click": {
@@ -4931,7 +4417,7 @@
       },
       "cookies": {},
       "id": "4fc95ff9-b785-49ee-8a8c-e789665a1643",
-      "domains": ["startlap.hu"]
+      "domains": ["startlap.hu", "nosalty.hu", "24.hu", "nlc.hu"]
     },
     {
       "click": {
@@ -4944,7 +4430,7 @@
     },
     {
       "click": {
-        "optIn": "div#gdpr-trigger",
+        "optIn": "div.gdpr-trigger",
         "presence": "div#gdpr"
       },
       "cookies": {},
@@ -5031,7 +4517,7 @@
       },
       "cookies": {},
       "id": "af566db1-982c-4837-8f0b-96a341702520",
-      "domains": ["sdna.gr"]
+      "domains": ["sdna.gr", "makeleio.gr"]
     },
     {
       "click": {
@@ -5099,7 +4585,7 @@
       },
       "cookies": {},
       "id": "d96f380c-c76f-47d8-a1f7-bd4063792ade",
-      "domains": ["ojogo.pt", "pik.bg", "prosport.ro"]
+      "domains": ["pik.bg", "prosport.ro"]
     },
     {
       "click": {
@@ -5128,6 +4614,161 @@
       "cookies": {},
       "id": "fbff28bd-84e5-4f82-8023-2f00d772e7e8",
       "domains": ["sorozatbarat.club"]
+    },
+    {
+      "click": {
+        "optIn": "button.snow-ali-kit_Button-Floating__button__ph4zrl",
+        "presence": "div.SnowPrivacyPolicyBanner_SnowPrivacyPolicyBanner__privacyPolicyBanner__1jg07"
+      },
+      "cookies": {},
+      "id": "407fe21e-7730-47f9-b83f-51d19dddc700",
+      "domains": ["aliexpress.ru"]
+    },
+    {
+      "click": {
+        "optIn": "a.cmptxt_btn_yes",
+        "optOut": "a.cmptxt_btn_no",
+        "presence": "div#cmpbox"
+      },
+      "cookies": {},
+      "id": "e735b61a-3a3f-418e-b2ff-93e3f8984d1b",
+      "domains": ["hrt.hr"]
+    },
+    {
+      "click": {
+        "optIn": "button.js-cb_accept",
+        "presence": "div.__cookies"
+      },
+      "cookies": {},
+      "id": "384b70c3-2458-4dc9-ac6f-d9c5e90cc62a",
+      "domains": ["ok.ru"]
+    },
+    {
+      "click": {
+        "optIn": "a.dismiss",
+        "presence": "div#cookie-disclaimer"
+      },
+      "cookies": {},
+      "id": "7cbce78d-ec34-4e9b-a4f5-5b401f155e36",
+      "domains": ["arukereso.hu"]
+    },
+    {
+      "click": {
+        "optIn": "div.cookieinfo-close",
+        "presence": "div.cookieinfo"
+      },
+      "cookies": {},
+      "id": "266c0df8-d8bc-4824-88d8-06d3970f0c2a",
+      "domains": ["glasistre.hr"]
+    },
+    {
+      "click": {
+        "optIn": "button.css-wum6af",
+        "presence": "div#qc-cmp2-container"
+      },
+      "cookies": {},
+      "id": "f081b651-7065-46a9-8d71-d7531850382e",
+      "domains": ["flash.pt"]
+    },
+    {
+      "click": {
+        "optIn": "a.cmpboxbtnyes ",
+        "presence": "div#cmpbox"
+      },
+      "cookies": {},
+      "id": "a2404864-0163-4f71-ab4c-915713f8f349",
+      "domains": ["nzz.ch"]
+    },
+    {
+      "click": {
+        "optIn": "label.c-notifier-btn",
+        "presence": "div.c-notifier-container"
+      },
+      "cookies": {
+        "optOut": [{ "name": "gdpr", "value": "[]" }]
+      },
+      "id": "3d2936df-3ca5-42fc-924b-1144c3d5b424",
+      "domains": ["ria.com"]
+    },
+    {
+      "click": {},
+      "cookies": { "optOut": [{ "name": "CONSENT", "value": "y" }] },
+      "id": "ff5b2d52-6cc0-47e5-a515-4a31c9207b81",
+      "domains": ["framar.bg"]
+    },
+    {
+      "click": {
+        "optIn": "button#acceptAllCookiesBtn",
+        "presence": "div#cookie-popover"
+      },
+      "cookies": {},
+      "id": "aa18156e-646e-4c5c-b550-6979d181f192",
+      "domains": ["sverigesradio.se"]
+    },
+    {
+      "click": {
+        "optIn": "a.btn",
+        "presence": "div#gdpr-box"
+      },
+      "cookies": {
+        "optIn": [{ "name": "privacy_accepted", "value": "1" }]
+      },
+      "id": "87d2bcfa-8685-4289-8c0a-d0fc31c74cc5",
+      "domains": ["naslovi.net"]
+    },
+    {
+      "click": {
+        "optIn": "button.orange-gradient",
+        "presence": "div.cookie-bar-wrap"
+      },
+      "cookies": {
+        "optIn": [{ "name": "politica_cookie", "value": "1" }]
+      },
+      "id": "84a2ec9b-bf4a-4638-aa94-d1b13652aae8",
+      "domains": ["dedeman.ro"]
+    },
+    {
+      "click": {
+        "optIn": "button.jad_cmp_paywall_button-cookies",
+        "presence": "div#cmp-main"
+      },
+      "cookies": {},
+      "id": "7d70347b-fe27-4c60-a9f2-6e0638f0ce37",
+      "domains": ["allocine.fr"]
+    },
+    {
+      "click": {
+        "optIn": "button.primary",
+        "presence": "div.cookie-consent-overlay"
+      },
+      "cookies": {},
+      "id": "be728b6d-8eeb-4179-beac-c1234fc0ae9f",
+      "domains": ["komplett.no"]
+    },
+    {
+      "click": {
+        "optIn": "div.cookieButton",
+        "presence": "div#cookieConsentContainer"
+      },
+      "cookies": {},
+      "id": "d8923166-cf05-4f6c-8829-270fc9b2efe1",
+      "domains": ["chmi.cz"]
+    },
+    {
+      "click": {
+        "optIn": "button.PONCHO-button--decide",
+        "presence": "div#TRCO-application"
+      },
+      "cookies": {
+        "optOut": [
+          {
+            "name": "cookie-policy-agreement",
+            "value": "%7B%22revision%22%3A20%2C%22consentLevel%22%3A1%7D"
+          }
+        ]
+      },
+      "id": "e63a688a-7eca-49b1-9b0f-bebae773a6ec",
+      "domains": ["anwb.nl"]
     }
   ]
 }


### PR DESCRIPTION
Added 31 new rules for:
centrum.sk, amazon.se, nlc.hu, aliexpress.ru, search.ch, hrt.hr, ok.ru, jn.pt, arukereso.hu, glasistre.hr, flash.pt, orange.sk, jeuxvideo.com, nzz.ch, echo24.cz, nosalty.hu, ria.com, framar.bg, sverigesradio.se, elisa.fi, dn.no, naslovi.net, dedeman.ro, drei.at, kurir.rs, allocine.fr, komplett.no, proximus.be, chmi.cz, anwb.nl, ansa.it. Removed broken cookie rules for:
mirror.co.uk, alza.cz, femina.hu, poste.it, kauppalehti.fi, news247.gr, alo.bg, borsonline.hu, rabobank.nl, informer.rs, eluniversal.com.mx, athensmagazine.gr, globo.com, express.co.uk, pronews.gr, nettiauto.com, sportdog.gr, emag.hu, ilgiornale.it, tradera.com, alo.rs, mobile.bg, observador.pt, napi.hu, telsu.fi, gossip-tv.gr, vi.nl, news.bg, zougla.gr, calciomercato.com, walmart.ca, newsbeast.gr, pomponik.pl, zerozero.pt, gp.se, katalozi.net, postnl.nl, tvp.pl, meo.pt.