### PR TITLE
Update facebook click rule to be more precise

### DIFF
--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -289,9 +289,9 @@
     },
     {
       "click": {
-        "optIn": "div.uiLayer div > button + button[type=submit]",
-        "optOut": "div.uiLayer div > button[type=submit]",
-        "presence": "div.uiLayer"
+        "optIn": "button[data-cookiebanner=\"accept_button\"]",
+        "optOut": "button[data-cookiebanner=\"accept_only_essential_button\"]",
+        "presence": "div[data-testid=\"cookie-policy-manage-dialog\"]"
       },
       "cookies": {},
       "id": "d1d8ba36-ced7-4453-8b17-2e051e0ab1eb",


### PR DESCRIPTION
This is to avoid false positives where we click elements which are unrelated to the cookie banner. 
This also fixes an issue where the Facebook rule only worked on Desktop, not Android.