### PR TITLE
Remove dot from rule id fixing RS sync error.

### DIFF
--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -28,7 +28,7 @@
       }
     },
     {
-      "id": "consentmanager.net",
+      "id": "consentmanagernet",
       "domains": [],
       "click": {
         "optIn": "#cmpwelcomebtnyes a",


### PR DESCRIPTION
`.` in rule ids seems to break the sync script. We only have one rule that uses it so I've updated the ID for now. We should check why exactly this fails and either fix it or update our JSON schema to disallow `.` in id fields.