### PR TITLE
Extended the rule for facebook.com to also work on messenger.com

### DIFF
--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -347,7 +347,7 @@
       },
       "cookies": {},
       "id": "d1d8ba36-ced7-4453-8b17-2e051e0ab1eb",
-      "domains": ["facebook.com"]
+      "domains": ["facebook.com", "messenger.com"]
     },
     {
       "cookies": {


### PR DESCRIPTION
This is a simple extension of a rule that already exists for facebook.com, which should now also apply to messenger.com, since both of these platforms reuse the same cookie banner.

In theory, oculus.com could also be added to the same rule, but in practice it's not that simple and clicking "Decline optional cookies" there causes the page to reload, which, from a UX perspective, may look weird when a user opens the page and it loads twice one after the other.

Closes #195