### PR TITLE
Extended the rule for facebook.com to also work on oculus.com

### DIFF
--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -347,7 +347,7 @@
       },
       "cookies": {},
       "id": "d1d8ba36-ced7-4453-8b17-2e051e0ab1eb",
-      "domains": ["facebook.com", "messenger.com"]
+      "domains": ["facebook.com", "messenger.com", "oculus.com"]
     },
     {
       "cookies": {


### PR DESCRIPTION
In this pull request, I extended the rule for facebook.com to also apply to oculus.com as per [#199 comment 1](https://github.com/mozilla/cookie-banner-rules-list/pull/199#issuecomment-1570308661).