### PR TITLE
Added new and improved existing rules for Stack Exchange websites

### DIFF
--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -292,25 +292,32 @@
       "domains": ["azure.microsoft.com"]
     },
     {
-      "click": {
-        "optIn": ".js-accept-cookies",
-        "presence": ".js-consent-banner"
-      },
+      "id": "71443ce9-15b8-4e07-b51b-1f2158521ea9",
+      "domains": [
+        "askubuntu.com",
+        "mathoverflow.net",
+        "serverfault.com",
+        "stackapps.com",
+        "stackexchange.com",
+        "stackoverflow.blog",
+        "stackoverflow.co",
+        "stackoverflow.com",
+        "stackoverflowteams.com",
+        "superuser.com"
+      ],
       "cookies": {
         "optOut": [
           {
             "name": "OptanonAlertBoxClosed",
-            "value": "2023-01-04T15:56:30.908Z"
+            "value": "2030-01-01T00:00:00.000Z"
           }
         ]
       },
-      "id": "71443ce9-15b8-4e07-b51b-1f2158521ea9",
-      "domains": [
-        "askubuntu.com",
-        "serverfault.com",
-        "stackexchange.com",
-        "stackoverflow.com"
-      ]
+      "click": {
+        "presence": ".js-consent-banner",
+        "optOut": ".js-reject-cookies",
+        "optIn": ".js-accept-cookies"
+      }
     },
     {
       "click": {


### PR DESCRIPTION
The existing rule responsible for rejecting cookies on the various Stack Exchange websites was not working correctly, so I updated the injected cookie and the date stored in it to one that won't become too old anytime soon. Apart from that, I added an opt-out click rule as a fallback in case this cookie stops working again somewhere in the future.

Also, I added a few other Stack Exchange websites that were missing.

I tested everything gradually, and it worked on my computer, but I'm not sure if it will work for other people as it did for me.

Resolves #41
Fixes #200