### PR TITLE
Added a new rule for some Valve websites

### DIFF
--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -5240,6 +5240,29 @@
       "cookies": {},
       "id": "8308357f-6a66-433d-bfc3-de401410c350",
       "domains": ["hubspot.com"]
+    },
+    {
+      "id": "63104024-41b5-4be5-8019-2c59eaaf612c",
+      "domains": ["steamcommunity.com", "steampowered.com"],
+      "cookies": {
+        "optIn": [
+          {
+            "name": "cookieSettings",
+            "value": "%7B%22version%22%3A1%2C%22preference_state%22%3A1%2C%22content_customization%22%3Anull%2C%22valve_analytics%22%3Anull%2C%22third_party_analytics%22%3Anull%2C%22third_party_content%22%3Anull%2C%22utm_enabled%22%3Atrue%7D"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "cookieSettings",
+            "value": "%7B%22version%22%3A1%2C%22preference_state%22%3A2%2C%22content_customization%22%3Anull%2C%22valve_analytics%22%3Anull%2C%22third_party_analytics%22%3Anull%2C%22third_party_content%22%3Anull%2C%22utm_enabled%22%3Atrue%7D"
+          }
+        ]
+      },
+      "click": {
+        "presence": "#cookiePrefPopup",
+        "optOut": "#rejectAllButton",
+        "optIn": "#acceptAllButton"
+      }
     }
   ]
 }


### PR DESCRIPTION
In this pull request, I added a completely new rule to the list for those Valve websites that display a cookie banner (i.e. steamcommunity.com and steampowered.com).

One issue I noticed during testing is that their cookie banner displays with a slight delay, so in some specific cases where the page loads slowly, the banner clicker may time out and miss its chance to close that banner (the default 3000 ms delay is not enough in this case).

On the other hand, it is not that bad since the cookie injector should take care of everything, and clicking will be just a fallback in case Valve messes something up and the cookie stops working correctly.

Resolves #205