### PR TITLE
Add cookie rule for ups.com

### DIFF
--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -5312,6 +5312,26 @@
         "presence": "#didomi-popup",
         "optIn": "#didomi-notice-agree-button"
       }
+    },
+    {
+      "id": "f462b0ee-4d17-4dcb-a951-1a23249227f6",
+      "domains": ["ups.com"],
+      "cookies": {
+        "optOut": [
+          {
+            "name": "HASSEENNOTICE",
+            "value": "TRUE"
+          },
+          {
+            "name": "CONSENTMGR",
+            "value": "c1:0%7Cc3:0%7Cc5:0%7Cc6:0%7Cc7:0%7Cc8:0"
+          }
+        ]
+      },
+      "click": {
+        "optIn": ".implicit_privacy_prompt > .close_btn_thick",
+        "presence": ".implicit_privacy_prompt"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Example URL

https://www.ups.com/ca/en/Home.page

## Screenshot

<img width="875" alt="Screenshot 2023-08-03 at 17 30 51" src="https://github.com/mozilla/cookie-banner-rules-list/assets/80652640/c32a20ef-f86b-4692-b5b8-005a9fd2a3f8">

Tested on Firefox 117.0b2