### PR TITLE
Limit theverge.com selectors inside the parent

### DIFF
--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -5016,8 +5016,8 @@
     },
     {
       "click": {
-        "optIn": "button.py-12",
-        "optOut": "button.text-blurple ",
+        "optIn": "div.duet--cta--cookie-banner button.py-12",
+        "optOut": "div.duet--cta--cookie-banner button.text-blurple",
         "presence": "div.duet--cta--cookie-banner"
       },
       "cookies": {},


### PR DESCRIPTION
The current selectors are too broad as those are about the button styles.

Fixes #214