### PR TITLE
Block cookie banner on gmx.net

### DIFF
--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -580,7 +580,7 @@
         ]
       },
       "id": "290db348-ced2-4f16-9954-da476d0aef01",
-      "domains": ["web.de"]
+      "domains": ["web.de", "gmx.net"]
     },
     {
       "click": {},


### PR DESCRIPTION
gmx.net and web.de share a lot of things, including the cookie banner.