### PR TITLE
Add rule for yahoo.com, engadget.com, and techcrunch.com

### DIFF
--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -5484,6 +5484,14 @@
           }
         ]
       }
+    },
+    {
+      "id": "0c1f9dfe-0796-4498-9433-4a5578c5a254",
+      "domains": ["engadget.com", "yahoo.com", "techcrunch.com"],
+      "click": {
+        "optOut": "#login-form-gpc-donotallow",
+        "presence": "#consent-gpc-popUp"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Example URLs

- https://www.yahoo.com
- https://www.engadget.com
- https://techcrunch.com

Fixes #215 (includes additional steps to reproduce).

## Screenshot

![Screenshot 2023-11-14 at 10 07 04](https://github.com/mozilla/cookie-banner-rules-list/assets/80652640/8b21b3e7-7bab-4ab7-9e0f-5586045e84b3)

Tested on Firefox 120.0b9