### PR TITLE
apply the netcup rule for more domains

### DIFF
--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -5264,7 +5264,7 @@
     },
     {
       "id": "dea34d82-9c05-4c08-9262-18a7f62be91e",
-      "domains": ["netcup.de"],
+      "domains": ["netcup.de", "netcup-news.de", "netcup-sonderangebote.de"],
       "cookies": {
         "optOut": [
           {


### PR DESCRIPTION
There is already a rule for netcup.de. The same rule can be used for netcup-news.de and netcup-sonderangebote.de.