### PR TITLE
Added a new rule for Dell websites

### DIFF
--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -5964,6 +5964,15 @@
         "optOut": ".decline-button",
         "optIn": ".agree-button"
       }
+    },
+    {
+      "id": "f1849b07-95e8-4ae0-a99d-24df5abbb3cb",
+      "domains": ["dell.com", "delltechnologies.com"],
+      "click": {
+        "presence": ".cc-window",
+        "optOut": ".cc-dismiss",
+        "optIn": ".cc-allow"
+      }
     }
   ]
 }


### PR DESCRIPTION
This is a rule I initially planned to commit with all the other tech company websites in #333, but it looks like it might be a (heavily modified?) cookie consent manager from some CMP.

The use of the `.cc-window`, `.cc-dismiss`, and `.cc-allow` classes might suggest that this is the Cookie Consent by Insites (https://web.archive.org/web/20190520103530/https://cookieconsent.insites.com/ ), but both the JS code responsible for handling cookies is completely different, and the design of the cookie banner itself also stands out. This can't be it, I think.

For the time being, I propose adding this Dell rule to the list, and perhaps there will be time in the future to further investigate this matter.

Resolves #338