### PR TITLE
Added a new rule for Eclipse websites

### DIFF
--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -5964,6 +5964,42 @@
         "optOut": ".decline-button",
         "optIn": ".agree-button"
       }
+    },
+    {
+      "id": "92361e84-664e-46b3-ae55-95bc185dc88e",
+      "domains": [
+        "adoptium.net",
+        "eclipse-ee4j.github.io",
+        "eclipse.dev",
+        "eclipse.org",
+        "glassfish.org",
+        "jakarta.ee",
+        "mbse-capella.org",
+        "oniroproject.org",
+        "open-vsx.org",
+        "openmdm.org",
+        "osgi.org",
+        "planeteclipse.org"
+      ],
+      "cookies": {
+        "optIn": [
+          {
+            "name": "eclipse_cookieconsent_status",
+            "value": "allow"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "eclipse_cookieconsent_status",
+            "value": "deny"
+          }
+        ]
+      },
+      "click": {
+        "presence": ".cc-window",
+        "optOut": ".cc-deny",
+        "optIn": ".cc-allow"
+      }
     }
   ]
 }


### PR DESCRIPTION
In this pull request, I added a new rule for Eclipse websites and websites of Eclipse-affiliated or owned projects that display a cookie banner.

One important note, the cookie banner used by Eclipse on their various websites appears to be some kind of cookie consent manager from some CMP. I presume this is a slightly customized Cookie Consent by Insites (https://web.archive.org/web/20190520103530/https://cookieconsent.insites.com/ ).

I would consider converting this site-specific rule to a global rule, but the use of this CMP by various websites has a few catches, and it won't be as easy as it might seem. Currently, I don't have enough time to get into it.

Resolves #340