### PR TITLE
Added a new global rule for CookieScript

### DIFF
--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -82,6 +82,15 @@
       }
     },
     {
+      "id": "cookiescript",
+      "domains": [],
+      "click": {
+        "presence": "#cookiescript_injected",
+        "optOut": "#cookiescript_reject",
+        "optIn": "#cookiescript_accept"
+      }
+    },
+    {
       "id": "disabled",
       "domains": [
         "tumblr.com",
@@ -4828,16 +4837,6 @@
       },
       "id": "522a2d72-8131-406e-b058-b27ec07808fc",
       "domains": ["vodafone.pt"]
-    },
-    {
-      "click": {
-        "optIn": "div#cookiescript_accept",
-        "optOut": "div#cookiescript_reject ",
-        "presence": "div#cookiescript_injected"
-      },
-      "cookies": {},
-      "id": "7f8a8bfd-343c-4fa5-969b-35a0690f6f4f",
-      "domains": ["idealmedia.io"]
     },
     {
       "click": {


### PR DESCRIPTION
> When reviewing, please keep in mind that this is my first/one of the first attempts to make a global rule public and available to all users. I have done my best to test everything thoroughly on various websites, but I'm afraid that due to my lack of experience in this regard, I may have messed something up, and the rule will not work as expected (in some corner cases, for example).

In this pull request, I propose adding support for the CookieScript CMP, which is used in the wild by various websites on the Internet, and removing the one site-specific rule that will no longer be necessary thanks to this new global rule.

If you would like to test the correctness of this rule on the home page of this CMP, let me tell you right away that the banner there is displayed with a delay of more than 5 seconds, and as a result, it slips unnoticed by the cookie presence detector. Other websites on which I have tested this rule do not seem to have such a delay.

One important thing to note is that interacting with this banner during its fade-in animation may cause it to get stuck in a semi-transparent state for some time (see attached screenshot below), after which it should disappear very very slowly. It all depends on when the interaction with the cookie accept/reject button occurs. If it happens during the animation, the banner will remain semi-transparent for some time and then disappear. However, if it happens after the animation is over, the banner will then close as expected. Of course, such banner can then be waited out or closed manually, but this defeats the purpose of the automatic cookie blocker in Firefox. That's why I'm marking this PR as a draft, as I don't know what to do in this situation.

This is what the banner may look like after interrupting its animation:
![Interrupted-banner-fade-in-animation](https://github.com/mozilla/cookie-banner-rules-list/assets/34160838/f694d88d-dd5c-4eeb-8758-310de12d7a0b)

Resolves #348
Resolves #467