### PR TITLE
Added a new global rule for CookieYes

### DIFF
--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -82,6 +82,15 @@
       }
     },
     {
+      "id": "cookieyes",
+      "domains": [],
+      "click": {
+        "presence": "#cky-consent, .cky-consent-container",
+        "optOut": ".cky-btn-reject",
+        "optIn": ".cky-btn-accept"
+      }
+    },
+    {
       "id": "disabled",
       "domains": [
         "tumblr.com",
@@ -4880,16 +4889,6 @@
     },
     {
       "click": {
-        "optIn": "button.cky-btn-accept",
-        "optOut": "button.cky-btn-reject",
-        "presence": "div.cky-consent-bar"
-      },
-      "cookies": {},
-      "id": "b3b80b81-90f0-497f-b78c-53b611d4dfaf",
-      "domains": ["hugedomains.com"]
-    },
-    {
-      "click": {
         "optIn": ".cc-btn.cc-allow",
         "optOut": ".cc-btn.cc-deny",
         "presence": ".cc-window.cc-banner"
@@ -5342,16 +5341,6 @@
         "optOut": ".CookiesAlert_cookiesAlert__3qSl1 .Button_button__3Me73",
         "presence": ".CookiesAlert_cookiesAlert__3qSl1"
       }
-    },
-    {
-      "id": "536f8027-111f-4798-a9ef-745b30fe65c8",
-      "domains": ["met.ie"],
-      "click": {
-        "optOut": ".cky-btn.cky-btn-reject",
-        "optIn": ".cky-btn.cky-btn-accept",
-        "presence": ".cky-consent-bar"
-      },
-      "cookies": {}
     },
     {
       "id": "9f5f0c06-5221-45b2-a174-7d70fd128eb3",


### PR DESCRIPTION
> When reviewing, please keep in mind that this is my first/one of the first attempts to make a global rule public and available to all users. I have done my best to test everything thoroughly on various websites, but I'm afraid that due to my lack of experience in this regard, I may have messed something up, and the rule will not work as expected (in some corner cases, for example).

In this pull request, I propose adding support for the CookieYes CMP, which is used in the wild by various websites on the Internet, and removing the site-specific rules that will no longer be necessary thanks to this new global rule.

Resolves #349