### PR TITLE
Added a new global rule for HubSpot Cookie Consent

### DIFF
--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -82,6 +82,15 @@
       }
     },
     {
+      "id": "hubspotcookieconsent",
+      "domains": [],
+      "click": {
+        "presence": "#hs-eu-cookie-confirmation",
+        "optOut": "#hs-eu-decline-button",
+        "optIn": "#hs-eu-confirmation-button"
+      }
+    },
+    {
       "id": "disabled",
       "domains": [
         "tumblr.com",
@@ -4988,16 +4997,6 @@
       "cookies": {},
       "id": "ca37bf31-bf4e-4172-bf7e-91baca32c9e2",
       "domains": ["adjust.com"]
-    },
-    {
-      "click": {
-        "optIn": "button#hs-eu-confirmation-button",
-        "optOut": "button#hs-eu-decline-button",
-        "presence": "div#hs-eu-cookie-confirmation"
-      },
-      "cookies": {},
-      "id": "8308357f-6a66-433d-bfc3-de401410c350",
-      "domains": ["hubspot.com"]
     },
     {
       "id": "63104024-41b5-4be5-8019-2c59eaaf612c",


### PR DESCRIPTION
> When reviewing, please keep in mind that this is my first/one of the first attempts to make a global rule public and available to all users. I have done my best to test everything thoroughly on various websites, but I'm afraid that due to my lack of experience in this regard, I may have messed something up, and the rule will not work as expected (in some corner cases, for example).

In this pull request, I propose adding support for the HubSpot Cookie Consent CMP, which is used in the wild by various websites on the Internet, and removing the site-specific rules that will no longer be necessary thanks to this new global rule.

Resolves #352