### PR TITLE
Added a new global rule for ihavecookies

### DIFF
--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -82,6 +82,14 @@
       }
     },
     {
+      "id": "ihavecookies",
+      "domains": [],
+      "click": {
+        "presence": "#gdpr-cookie-message",
+        "optIn": "#gdpr-cookie-accept"
+      }
+    },
+    {
       "id": "disabled",
       "domains": [
         "tumblr.com",


### PR DESCRIPTION
> When reviewing, please keep in mind that this is my first/one of the first attempts to make a global rule public and available to all users. I have done my best to test everything thoroughly on various websites, but I'm afraid that due to my lack of experience in this regard, I may have messed something up, and the rule will not work as expected (in some corner cases, for example).

In this pull request, I propose adding support for the ihavecookies CMP, which is used in the wild by various websites on the Internet.

Resolves #354