### PR TITLE
Added BBC advertising banner

### DIFF
--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -4148,12 +4148,20 @@
     },
     {
       "click": {
+        "optIn": ".sp_choice_type_11",
         "optOut": ".sp_choice_type_13",
         "presence": ".message-container > #notice",
         "runContext": "child"
       },
       "cookies": {},
-      "domains": ["aktuality.sk", "sky.it", "azet.sk"],
+      "domains": [
+        "aktuality.sk",
+        "sky.it",
+        "azet.sk",
+        "privacy-mgmt.com",
+        "bbc.co.uk",
+        "bbc.com"
+      ],
       "id": "ae8f7761-35ff-45b2-92df-7868ca288ad2"
     },
     {


### PR DESCRIPTION
BBC actually has two cookie banners, and the one about “advertising cookies” has a one-click opt-out. `privacy-mgmt.com` is the frame location.

I checked, and all the existing domains in that entry also have an opt-in button, so I added this one for sake of completeness.