### PR TITLE
Add a global rule for CCM19

### DIFF
--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -6049,6 +6049,15 @@
         "optOut": ".CookieBanner_buttonContainer__NOZxH:nth-child(2) button",
         "presence": ".CookieBanner_cookieBanner__R_BOh"
       }
+    },
+    {
+      "id": "ccm19",
+      "click": {
+        "optIn": ".ccm--save-settings",
+        "optOut": ".ccm--decline-cookies",
+        "presence": "#ccm-widget"
+      },
+      "domains": []
     }
   ]
 }


### PR DESCRIPTION
See https://www.ccm19.de/en/, CCM19 is used by many primarily German websites. In addition to their own website, a quick search finds for example krafotec.de, formdimensionen.com, bekumoo.de.