### PR TITLE
updated existing rule to support two Sports Interactive domains

### DIFF
--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -2929,7 +2929,7 @@
       },
       "cookies": {},
       "id": "9e4d932a-eaf9-44e4-a3ac-55861d66a7c3",
-      "domains": ["metoffice.gov.uk"]
+      "domains": ["metoffice.gov.uk", "footballmanager.com", "sigames.com"]
     },
     {
       "click": {


### PR DESCRIPTION
Updated existing site-specific rule to support two Sports Interactive domains.

Fixes #242.