### PR TITLE
updated existing rule to support ieee.org and linuxfoundation.eu

### DIFF
--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -4268,7 +4268,7 @@
       },
       "cookies": {},
       "id": "23710ccf-85e6-450e-953d-7ffc3f80bbf0",
-      "domains": ["slideshare.net"]
+      "domains": ["slideshare.net", "ieee.org"]
     },
     {
       "click": {

--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -3640,12 +3640,6 @@
       "domains": ["worldbank.org"]
     },
     {
-      "click": { "optIn": "a.cc-dismiss", "presence": "div.cc-banner" },
-      "cookies": {},
-      "id": "4ec563ab-ef41-4aa7-8da6-58227000fe1d",
-      "domains": ["ieee.org"]
-    },
-    {
       "click": { "optIn": "button.css-1k47zha", "presence": "div#qc-cmp2-ui" },
       "cookies": {},
       "id": "6c246e7d-2a12-4b13-94b4-d2908cd64aad",

--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -4262,7 +4262,7 @@
       },
       "cookies": {},
       "id": "23710ccf-85e6-450e-953d-7ffc3f80bbf0",
-      "domains": ["slideshare.net", "ieee.org"]
+      "domains": ["slideshare.net", "ieee.org", "linuxfoundation.eu"]
     },
     {
       "click": {


### PR DESCRIPTION
Updated existing site-specific rule to support ieee.org and linuxfoundation.eu.

Fixes #63. See #254.