### PR TITLE
Added a new rule for teamspeak.com

### DIFF
--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -6049,6 +6049,36 @@
         "optOut": ".CookieBanner_buttonContainer__NOZxH:nth-child(2) button",
         "presence": ".CookieBanner_cookieBanner__R_BOh"
       }
+    },
+    {
+      "id": "8005fd7b-26ec-43c0-ad94-1c6834cc7905",
+      "domains": ["teamspeak.com"],
+      "cookies": {
+        "optIn": [
+          {
+            "name": "cookieControl",
+            "value": "true"
+          },
+          {
+            "name": "cookieControlPrefs",
+            "value": "[\"analytics\",\"marketing\"]"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "cookieControl",
+            "value": "true"
+          },
+          {
+            "name": "cookieControlPrefs",
+            "value": "[]"
+          }
+        ]
+      },
+      "click": {
+        "presence": "#gdpr-cookie-message",
+        "optIn": "#gdpr-cookie-accept"
+      }
     }
   ]
 }


### PR DESCRIPTION
Admittedly, the cookie banner that is used on teamspeak.com should be supported after my PR #361 for the ihavecookies CMP is merged, but only partially, as that global rule only supports accepting cookies.

So, for teamspeak.com to be fully supported, something else needs to be done. Unfortunately, in the current implementation of the cookie banner blocker in Firefox, it is not possible to either:
- click multiple times one after the other
- inject cookies in global rules.

Perhaps it will change in the future, but for now, in order to fully support this website, the only solution seems to be to create an almost identical rule to the one I already proposed in the other linked PR, but this time with support for injecting cookies.

Resolves #369