### PR TITLE
updated existing rule to support france24.com

### DIFF
--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -2576,7 +2576,8 @@
         "free.fr",
         "markiza.sk",
         "willhaben.at",
-        "francetvinfo.fr"
+        "francetvinfo.fr",
+        "france24.com"
       ]
     },
     {


### PR DESCRIPTION
Updated existing site-specific rule to support france24.com.

Fixes #197.