### PR TITLE
fixed cookie rule for europa.eu

### DIFF
--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -431,11 +431,18 @@
     },
     {
       "click": {
-        "optIn": ".cck-actions div > button",
-        "optOut": ".cck-actions div > button + button",
-        "presence": "div#cookie-consent-banner"
+        "optIn": ".btn-accept-cookies",
+        "optOut": ".btn-refuse-cookies",
+        "presence": ".cookie-section"
       },
-      "cookies": {},
+      "cookies": {
+        "optOut": [
+          {
+            "name": "cck1",
+            "value": "%7B%22cm%22%3Atrue%2C%22all1st%22%3Afalse%2C%22closed%22%3Atrue%7D"
+          }
+        ]
+      },
       "id": "0c74749a-8c53-4bb0-b31a-ab2f89b7f493",
       "domains": ["europa.eu"]
     },


### PR DESCRIPTION
There is a cookie rule for europa.eu. The URL www.europa.eu redirects to european-union.europa.eu and there the following click rule no longer works:

```
"click": {
  "optIn": ".cck-actions div > button",
  "optOut": ".cck-actions div > button + button",
  "presence": "div#cookie-consent-banner"
}
```

Instead, it has to be:

```
"click": {
  "optIn": ".cck-actions > a",
  "optOut": ".cck-actions > a + a",
  "presence": "div#cookie-consent-banner"
}
```

But even after applying this rule, there is another banner that confirms your cookie choice. To hide that one, you have to set a cookie. The cookie is already enough to hide both, the original and the confirmation banner. Also, the rule does not work for www.consilium.europa.eu where another cookie banner solution is used.

Therefore (and because you don't support for subdomains yet), I combined both pages in one rule: The cookie is for european-union.europa.eu, while the click rule is for www.consilium.europa.eu.