### PR TITLE
Updated rule for asus.com in response to minor banner changes on the Asus side

### DIFF
--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -3953,14 +3953,13 @@
       "domains": ["tapad.com"]
     },
     {
-      "click": {
-        "optIn": "div.btn-ok",
-        "optOut": "div.btn-setting",
-        "presence": "div#cookie-policy-info"
-      },
-      "cookies": {},
       "id": "8c949b75-4c7b-4559-8ade-780064af370a",
-      "domains": ["asus.com"]
+      "domains": ["asus.com"],
+      "click": {
+        "presence": "#cookie-policy-info",
+        "optOut": ".btn-reject",
+        "optIn": ".btn-ok"
+      }
     },
     {
       "click": { "optIn": "button#unic-agree", "presence": "div.unic-bar" },


### PR DESCRIPTION
This is a quick update to the existing click rule for asus.com in response to the recent minor cookie banner changes on the Asus side, as described in the linked GitHub issue below.

Fixes #434