### PR TITLE
updated existing rule to support Anexia and two more Netcup domains

### DIFF
--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -5353,7 +5353,14 @@
     },
     {
       "id": "dea34d82-9c05-4c08-9262-18a7f62be91e",
-      "domains": ["netcup.de", "netcup-news.de", "netcup-sonderangebote.de"],
+      "domains": [
+        "anexia.com",
+        "netcup.com",
+        "netcup.de",
+        "netcup.eu",
+        "netcup-news.de",
+        "netcup-sonderangebote.de"
+      ],
       "cookies": {
         "optOut": [
           {


### PR DESCRIPTION
Updated existing rule to support Anexia and two more Netcup domains. The domain netcup.com redirects to netcup.eu, but the rule for netcup.com is there to support helpcenter.netcup.com.