### PR TITLE
added rule for autoscout24

### DIFF
--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -6212,6 +6212,14 @@
         "optOut": "[data-cookieman-accept-none]",
         "presence": "#cookieman-modal"
       }
+    },
+    {
+      "id": "46FECFD3-2384-450A-8CCC-53BCFE65DF4C",
+      "domains": ["autoscout24.at", "autoscout24.de"],
+      "click": {
+        "optIn": "button[data-testid=\"as24-cmp-accept-all-button\"]",
+        "presence": "#as24-cmp-popup"
+      }
     }
   ]
 }

--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -6217,7 +6217,7 @@
       "id": "46FECFD3-2384-450A-8CCC-53BCFE65DF4C",
       "domains": ["autoscout24.at", "autoscout24.de"],
       "click": {
-        "optIn": "button[data-testid=\"as24-cmp-accept-all-button\"]",
+        "optIn": "[data-testid=\"as24-cmp-accept-all-button\"]",
         "presence": "#as24-cmp-popup"
       }
     }


### PR DESCRIPTION
Added rule for autoscout24.

Fixes #415.

When testing, I noticed that sometimes the banner is not hidden the first time. But after reloading the page, the banner was always hidden in my tests.