### PR TITLE
Add rule for thenextweb.com

### DIFF
--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -6220,7 +6220,7 @@
         "optOut": [
           {
             "name": "__tnw_cookieConsent",
-            "value": "ad_storage=denied&analytics_storage=denied"
+            "value": "{%22ad_storage%22:%22denied%22%2C%22analytics_storage%22:%22denied%22}"
           }
         ]
       },

--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -6212,6 +6212,22 @@
         "optOut": "[data-cookieman-accept-none]",
         "presence": "#cookieman-modal"
       }
+    },
+    {
+      "id": "02c3c5e1-03a6-426a-b00b-fa34f62322fd",
+      "domains": ["thenextweb.com"],
+      "cookies": {
+        "optOut": [
+          {
+            "name": "__tnw_cookieConsent",
+            "value": "ad_storage=denied&analytics_storage=denied"
+          }
+        ]
+      },
+      "click": {
+        "optIn": ".cookie-consent-banner__btn-primary",
+        "presence": "#cookie-consent-banner"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Example URL

`https://www.thenextweb.com`

## Screenshot

![Screenshot 2024-01-14 at 16 08 42](https://github.com/mozilla/cookie-banner-rules-list/assets/80652640/a1f5375f-74a3-47f7-be05-1319ff4cb118)

Tested on Firefox 122.0b9