### PR TITLE
fixed rule for several Stack Exchange domains

### DIFF
--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -287,7 +287,14 @@
         "seagate.com",
         "soundcloud.com",
         "trello.com",
-        "unrealengine.com"
+        "unrealengine.com",
+        "askubuntu.com",
+        "mathoverflow.net",
+        "serverfault.com",
+        "stackapps.com",
+        "stackexchange.com",
+        "stackoverflow.com",
+        "superuser.com"
       ]
     },
     {
@@ -479,16 +486,9 @@
     {
       "id": "71443ce9-15b8-4e07-b51b-1f2158521ea9",
       "domains": [
-        "askubuntu.com",
-        "mathoverflow.net",
-        "serverfault.com",
-        "stackapps.com",
-        "stackexchange.com",
         "stackoverflow.blog",
         "stackoverflow.co",
-        "stackoverflow.com",
-        "stackoverflowteams.com",
-        "superuser.com"
+        "stackoverflowteams.com"
       ],
       "cookies": {
         "optOut": [


### PR DESCRIPTION
I moved several Stack Exchange domains to a different rule as the previous selector is no longer valid for these domains.