### PR TITLE
Update existing rule to support numerama.com

### DIFF
--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -1607,6 +1607,7 @@
       "domains": [
         "theconversation.com",
         "leparisien.fr",
+        "numerama.com",
         "jofogas.hu",
         "orange.fr",
         "meteofrance.com",


### PR DESCRIPTION
![image](https://github.com/mozilla/cookie-banner-rules-list/assets/17053707/011d3976-4ae7-45ab-814d-76ec8e4db57d)

Tested on Firefox 122.0