### PR TITLE
Update existing rule to support lesechos.fr

### DIFF
--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -1607,6 +1607,7 @@
       "domains": [
         "theconversation.com",
         "leparisien.fr",
+        "lesechos.fr",
         "jofogas.hu",
         "orange.fr",
         "meteofrance.com",


### PR DESCRIPTION
# Example URLs
https://www.lesechos.fr/
https://investir.lesechos.fr/

# Screenshot
![image](https://github.com/mozilla/cookie-banner-rules-list/assets/17053707/74638846-d1b7-4417-8cc7-9465d96afc4e)

Tested on Firefox 122.0