### PR TITLE
Update existing rule to support radiofrance.fr

### DIFF
--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -2707,7 +2707,8 @@
         "opodo.nl",
         "opodo.no",
         "opodo.pl",
-        "opodo.pt"
+        "opodo.pt",
+        "radiofrance.fr"
       ]
     },
     {


### PR DESCRIPTION
# Example URLs
https://www.radiofrance.fr/

# Screenshot
![image](https://github.com/mozilla/cookie-banner-rules-list/assets/17053707/dc6c4315-8566-4f58-8398-95a91a25f879)

Tested of Firefox 123.0