### PR TITLE
Add new rule for but.fr

### DIFF
--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -6311,6 +6311,15 @@
       }
     },
     {
+      "id": "3030D307-A610-4F3D-B589-D2BE133850D7",
+      "domains": ["but.fr"],
+      "click": {
+        "optIn": "#popin_tc_privacy_button",
+        "optOut": "#popin_tc_privacy_button_2",
+        "presence": "#tc-privacy-wrapper"
+      }
+    },
+    {
       "id": "3FD9FDA8-5F69-46C4-BA33-35FE3C804B4C",
       "domains": ["stepstone.de"],
       "click": {


### PR DESCRIPTION
# Example URLs
https://www.but.fr/

# Screenshot
![image](https://github.com/mozilla/cookie-banner-rules-list/assets/17053707/96a1b8f8-eefc-4bcc-ba9e-2bf917f2b551)

Tested on Firefox 123.0