### PR TITLE
Move bloomberg domain to rule with optOut

### DIFF
--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -4204,7 +4204,6 @@
         "focus.de",
         "bild.de",
         "computerbild.de",
-        "bloomberg.com",
         "t-online.de",
         "wetteronline.de",
         "chip.de",
@@ -4282,7 +4281,7 @@
         "runContext": "child"
       },
       "cookies": {},
-      "domains": ["aktuality.sk", "sky.it", "azet.sk"],
+      "domains": ["aktuality.sk", "sky.it", "azet.sk", "bloomberg.com"],
       "id": "ae8f7761-35ff-45b2-92df-7868ca288ad2"
     },
     {


### PR DESCRIPTION
The banner on bloomberg.com has an optOut button that should be used.
Today the banner is not clicked if cookiebanners.service.mode = 1.

# Example Url
https://www.bloomberg.com/

# Screenshot
![image](https://github.com/mozilla/cookie-banner-rules-list/assets/17053707/e4d656b3-f998-4dc1-a3e8-b997e8f9e415)

Tested on Firefox 123.0