### PR TITLE
Add didomi sites

### DIFF
--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -1199,7 +1199,6 @@
         "actu.fr",
         "hbvl.be",
         "naszemiasto.pl",
-        "leboncoin.fr",
         "rtbf.be",
         "20minutos.es",
         "sudinfo.be",
@@ -1672,7 +1671,8 @@
         "hasznaltauto.hu",
         "zdnet.de",
         "intersport.fr",
-        "decathlon.fr"
+        "decathlon.fr",
+        "leboncoin.fr"
       ]
     },
     {

--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -1674,7 +1674,8 @@
         "decathlon.fr",
         "leboncoin.fr",
         "boursorama.com",
-        "boursobank.com"
+        "boursobank.com",
+        "intermarche.com"
       ]
     },
     {

--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -1671,7 +1671,8 @@
         "subito.it",
         "hasznaltauto.hu",
         "zdnet.de",
-        "intersport.fr"
+        "intersport.fr",
+        "decathlon.fr"
       ]
     },
     {

--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -1672,7 +1672,9 @@
         "zdnet.de",
         "intersport.fr",
         "decathlon.fr",
-        "leboncoin.fr"
+        "leboncoin.fr",
+        "boursorama.com",
+        "boursobank.com"
       ]
     },
     {

--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -1670,7 +1670,8 @@
         "meteofrance.com",
         "subito.it",
         "hasznaltauto.hu",
-        "zdnet.de"
+        "zdnet.de",
+        "intersport.fr"
       ]
     },
     {


### PR DESCRIPTION
Adds 2 sites using didomi and move a third one to a rule with an optOut

1. Add https://www.intersport.fr/
![image](https://github.com/mozilla/cookie-banner-rules-list/assets/17053707/b7c0a123-3079-4b79-844c-1be4d0724fc9)
2. Add https://www.decathlon.fr/
![image](https://github.com/mozilla/cookie-banner-rules-list/assets/17053707/24372af3-c8f9-4b04-88c9-8dc9bf962778)
3. Move https://www.leboncoin.fr/
![image](https://github.com/mozilla/cookie-banner-rules-list/assets/17053707/f82198a7-f03d-4f09-b492-befad5d8d4e4)

Tested on Firefox 123.0