### PR TITLE
Added support for krux.tech and spcgear.com as well

### DIFF
--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -5856,7 +5856,7 @@
     },
     {
       "id": "04e919eb-13c2-4b37-bf7f-888767888640",
-      "domains": ["endorfy.com", "silentiumpc.com"],
+      "domains": ["endorfy.com", "krux.tech", "silentiumpc.com", "spcgear.com"],
       "cookies": {
         "optOut": [
           {


### PR DESCRIPTION
In this pull request, I modified the existing rule for silentiumpc.com to add support for krux.tech and spcgear.com, two more domains owned by the same company (Cooling sp. z o.o.).

Resolves #460