### PR TITLE
Re-added support for endorfy.com

### DIFF
--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -5856,7 +5856,7 @@
     },
     {
       "id": "04e919eb-13c2-4b37-bf7f-888767888640",
-      "domains": ["endorfy.com", "silentiumpc.com"],
+      "domains": ["silentiumpc.com"],
       "cookies": {
         "optOut": [
           {
@@ -5868,6 +5868,29 @@
       "click": {
         "presence": "#cookie-law-info-bar",
         "optIn": "#wt-cli-accept-all-btn"
+      }
+    },
+    {
+      "id": "1be1e4d7-bcad-4fc8-a348-ae64af8bcac7",
+      "domains": ["endorfy.com"],
+      "cookies": {
+        "optIn": [
+          {
+            "name": "moove_gdpr_popup",
+            "value": "%7B%22strict%22%3A%221%22%2C%22thirdparty%22%3A%221%22%2C%22advanced%22%3A%221%22%7D"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "moove_gdpr_popup",
+            "value": "%7B%22strict%22%3A%221%22%2C%22thirdparty%22%3A%220%22%2C%22advanced%22%3A%220%22%7D"
+          }
+        ]
+      },
+      "click": {
+        "presence": "#moove_gdpr_cookie_info_bar",
+        "optOut": ".moove-gdpr-infobar-reject-btn",
+        "optIn": ".moove-gdpr-infobar-allow-all"
       }
     },
     {


### PR DESCRIPTION
In this pull request, I separated endorfy.com into its own rule, as it recently started using a different cookie banner, which the current rule was not prepared for. For more information, see the linked GitHub issue below.

Fixes #463