### PR TITLE
Update existing rule to add fnac.com, .be and .pt

### DIFF
--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -107,7 +107,7 @@
     {
       "click": {
         "optIn": "button#onetrust-accept-btn-handler",
-        "optOut": ".ot-pc-refuse-all-handler, #onetrust-reject-all-handler",
+        "optOut": ".ot-pc-refuse-all-handler, #onetrust-reject-all-handler, .onetrust-close-btn-handler",
         "presence": "div#onetrust-consent-sdk"
       },
       "cookies": {},
@@ -294,7 +294,10 @@
         "stackapps.com",
         "stackexchange.com",
         "stackoverflow.com",
-        "superuser.com"
+        "superuser.com",
+        "fnac.com",
+        "fnac.be",
+        "fnac.pt"
       ]
     },
     {

--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -411,6 +411,16 @@
     },
     {
       "click": {
+        "optIn": "button#onetrust-accept-btn-handler",
+        "optOut": "button.onetrust-close-btn-handler",
+        "presence": "div#onetrust-consent-sdk"
+      },
+      "cookies": {},
+      "id": "2d821158-5945-4134-a078-56c6da4f678d",
+      "domains": ["fnac.be", "fnac.ch", "fnac.com", "fnac.pt"]
+    },
+    {
+      "click": {
         "optIn": ".qc-cmp2-summary-buttons > :nth-child(3)",
         "optOut": ".qc-cmp2-summary-buttons > :nth-child(2)",
         "presence": "#qc-cmp2-container"

--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -107,7 +107,7 @@
     {
       "click": {
         "optIn": "button#onetrust-accept-btn-handler",
-        "optOut": ".ot-pc-refuse-all-handler, #onetrust-reject-all-handler, .onetrust-close-btn-handler",
+        "optOut": ".ot-pc-refuse-all-handler, #onetrust-reject-all-handler",
         "presence": "div#onetrust-consent-sdk"
       },
       "cookies": {},
@@ -294,10 +294,7 @@
         "stackapps.com",
         "stackexchange.com",
         "stackoverflow.com",
-        "superuser.com",
-        "fnac.com",
-        "fnac.be",
-        "fnac.pt"
+        "superuser.com"
       ]
     },
     {


### PR DESCRIPTION
* https://www.fnac.com/
![image](https://github.com/mozilla/cookie-banner-rules-list/assets/17053707/949e2622-d2d7-4460-a1ad-bf03449ae7a9)

* https://www.fnac.pt/
![image](https://github.com/mozilla/cookie-banner-rules-list/assets/17053707/61390e38-0acd-4355-9a03-0fbb22d09c55)

* https://www.nl.fnac.be/
![image](https://github.com/mozilla/cookie-banner-rules-list/assets/17053707/1eb6eacf-9c7d-4eb1-b1bf-b5990f7b78c6)

* https://www.fr.fnac.ch/
![image](https://github.com/mozilla/cookie-banner-rules-list/assets/17053707/d7bff6fc-fbff-4eb4-843c-f64f423edcc5)

Tested of Firefox 123.0.1