### PR TITLE
Update rule to add gog.com

### DIFF
--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -6193,7 +6193,7 @@
     },
     {
       "id": "04afc564-14b2-4c56-b72d-47a26e121f3b",
-      "domains": ["action.com"],
+      "domains": ["action.com", "gog.com"],
       "click": {
         "presence": "#cookiebanner",
         "optOut": "#CybotCookiebotDialogBodyLevelButtonLevelOptinDeclineAll",


### PR DESCRIPTION
https://www.gog.com/

![image](https://github.com/mozilla/cookie-banner-rules-list/assets/17053707/864f0177-0a4b-496a-877b-ab968b2b043a)

Tested of Firefox 123.0.1