### PR TITLE
Removed support for zyxel.com for now due to a banner change to a different one

### DIFF
--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -6267,7 +6267,7 @@
     },
     {
       "id": "7AF1C34C-750E-44FC-A3C4-31FB61EBF71B",
-      "domains": ["deskmodder.de"],
+      "domains": ["deskmodder.de", "zyxel.com"],
       "click": {
         "optIn": "#cookiescript_accept",
         "optOut": "#cookiescript_reject",

--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -6098,33 +6098,6 @@
       }
     },
     {
-      "id": "351f17c2-54b7-4a43-a425-b53bf5950b2e",
-      "domains": ["zyxel.com"],
-      "cookies": {
-        "optIn": [
-          {
-            "name": "cookie-agreed",
-            "value": "2"
-          },
-          {
-            "name": "cookie-agreed-version",
-            "value": "1.0.0"
-          }
-        ],
-        "optOut": [
-          {
-            "name": "cookie-agreed",
-            "value": "0"
-          }
-        ]
-      },
-      "click": {
-        "presence": ".eu-cookie-compliance-banner",
-        "optOut": ".decline-button",
-        "optIn": ".agree-button"
-      }
-    },
-    {
       "id": "ddff9528-161c-471e-bd2d-ba4d874a3931",
       "domains": ["nazwa.pl"],
       "cookies": {


### PR DESCRIPTION
In this pull request, I removed the site-specific rule for zyxel.com, as it is now redundant and does not serve its purpose anymore since they started using the CookieScript CMP (for which support has already been proposed by me in another pull request and is waiting for review). See #467 and #356 for more information.