### PR TITLE
Create new TrustCommander rule for bank sites

### DIFF
--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -6311,6 +6311,15 @@
       }
     },
     {
+      "id": "98D89E26-F4B6-4C2D-BABF-4295B922E433",
+      "domains": ["fortuneo.fr", "lcl.fr"],
+      "click": {
+        "optIn": "#popin_tc_privacy_button_3",
+        "optOut": "#popin_tc_privacy_button_2",
+        "presence": "#tc-privacy-wrapper"
+      }
+    },
+    {
       "id": "3FD9FDA8-5F69-46C4-BA33-35FE3C804B4C",
       "domains": ["stepstone.de"],
       "click": {


### PR DESCRIPTION
1. https://www.fortuneo.fr/
![image](https://github.com/mozilla/cookie-banner-rules-list/assets/17053707/f9537b33-34aa-4ebb-859b-3efed1aa4dfa)

2. https://www.lcl.fr/
![image](https://github.com/mozilla/cookie-banner-rules-list/assets/17053707/8bed3062-bce0-44cc-ba3b-2409fb23b4cc)

Tested on Firefox 123.0.1