### PR TITLE
Added support for workplace.com from Meta

### DIFF
--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -530,7 +530,6 @@
       "domains": [
         "facebook.com",
         "messenger.com",
-        "meta.com",
         "oculus.com",
         "workplace.com"
       ],

--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -526,14 +526,19 @@
       "domains": ["youtube.com"]
     },
     {
-      "click": {
-        "optIn": "button[data-cookiebanner=\"accept_button\"]",
-        "optOut": "button[data-cookiebanner=\"accept_only_essential_button\"]",
-        "presence": "div[data-testid=\"cookie-policy-manage-dialog\"]"
-      },
-      "cookies": {},
       "id": "d1d8ba36-ced7-4453-8b17-2e051e0ab1eb",
-      "domains": ["facebook.com", "messenger.com", "oculus.com"]
+      "domains": [
+        "facebook.com",
+        "messenger.com",
+        "meta.com",
+        "oculus.com",
+        "workplace.com"
+      ],
+      "click": {
+        "presence": "[data-testid=\"cookie-policy-manage-dialog\"]",
+        "optOut": "[data-cookiebanner=\"accept_only_essential_button\"]",
+        "optIn": "[data-cookiebanner=\"accept_button\"]"
+      }
     },
     {
       "cookies": {


### PR DESCRIPTION
In this pull request, I modified the existing rule for the standard cookie banner used by Meta on a large part of their websites to add support for workplace.com. While I’m at it, I also added _partial_ support for meta.com (it only works on some web pages).

Resolves #473