### PR TITLE
Added support for instagram.com (desktop only)

### DIFF
--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -550,6 +550,33 @@
       }
     },
     {
+      "id": "9d29b82d-c438-4003-8573-54e1ad6fa031",
+      "domains": ["instagram.com"],
+      "click": {
+        "presence": "[role=\"dialog\"]",
+        "optOut": "[role=\"dialog\"] button + button",
+        "optIn": "[role=\"dialog\"] button:has(+ button)"
+      }
+    },
+    {
+      "id": "c232eab8-f55a-436a-8033-478746d05d98",
+      "domains": ["threads.net"],
+      "cookies": {
+        "optIn": [
+          {
+            "name": "cb",
+            "value": "1_2055_07_11_"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "cb",
+            "value": "1_2055_07_11_2-3"
+          }
+        ]
+      }
+    },
+    {
       "cookies": {
         "optOut": [
           {
@@ -5200,24 +5227,6 @@
         "optOut": "#footer_tc_privacy_button_2",
         "presence": ".tc-privacy-wrapper.tc-privacy-override.tc-privacy-wrapper"
       }
-    },
-    {
-      "cookies": {
-        "optOut": [
-          {
-            "name": "cb",
-            "value": "1_2055_07_11_2-3"
-          }
-        ],
-        "optIn": [
-          {
-            "name": "cb",
-            "value": "1_2055_07_11_"
-          }
-        ]
-      },
-      "id": "C232EAB8-F55A-436A-8033-478746D05D98",
-      "domains": ["threads.net"]
     },
     {
       "id": "05157ed1-12c2-4f84-9dff-718fae5bc096",


### PR DESCRIPTION
In this pull request, I created a brand new rule for instagram.com to add support for its desktop variant.

The way it works is that it searches for a group of two buttons that are direct siblings and descendants of an element whose role is a dialog. It seems to do the trick.

However, the rule has a few drawbacks:
1. It is based mainly on the position of the various elements in the tree, so any future change by Meta programmers may result in the _accept_ button and not the _reject_ button being selected, which is definitely not what we want. Or alternatively, everything will stop working altogether.
2. Since the new `:has()` pseudo-class is used here, this rule will only work correctly in Firefox 121 and newer, leaving Firefox 120 (where the cookie banner blocker was first enabled by default in private browsing windows for German users) and Firefox 115 ESR with a non-functional rule. This is not a big deal, as Firefox 120 is no longer supported since version 121 came out, and Firefox 115 ESR users enable this feature at their own risk, as it is hidden behind `about:config` prefs.
3. On mobile devices or with very small viewport sizes, Instagram switches to a different banner that has the cookie accept/reject buttons contained in `div`s within `div`s, and as a result, the buttons are no longer direct siblings, making the selector unable to find them. Therefore, a better solution than mine may be needed for #176.

Fixes #223