### PR TITLE
Added partial support for meta.com

### DIFF
--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -540,6 +540,7 @@
       "domains": [
         "facebook.com",
         "messenger.com",
+        "meta.com",
         "oculus.com",
         "workplace.com"
       ],


### PR DESCRIPTION
In this pull request, I modified the existing rule for the standard cookie banner used by Meta on a large part of their websites to add partial support for meta.com. In practice, only about.meta.com seems to be the beneficiary of this change, but it is still better than no support at all, isn't it?

Resolves #476