### PR TITLE
Add a few of the most visited sites in France

### DIFF
--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -6375,6 +6375,15 @@
       }
     },
     {
+      "id": "17B1F270-F499-451C-AED5-5C737106F003",
+      "domains": ["ovhcloud.com"],
+      "click": {
+        "optIn": "#header_tc_privacy_button_3",
+        "optOut": "#header_tc_privacy_button",
+        "presence": "#tc-privacy-wrapper"
+      }
+    },
+    {
       "id": "3FD9FDA8-5F69-46C4-BA33-35FE3C804B4C",
       "domains": ["stepstone.de"],
       "click": {

--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -6354,7 +6354,13 @@
     },
     {
       "id": "98D89E26-F4B6-4C2D-BABF-4295B922E433",
-      "domains": ["fortuneo.fr", "lcl.fr", "enedis.fr", "tf1.fr"],
+      "domains": [
+        "bouyguestelecom.fr",
+        "enedis.fr",
+        "fortuneo.fr",
+        "lcl.fr",
+        "tf1.fr"
+      ],
       "click": {
         "optIn": "#popin_tc_privacy_button_3",
         "optOut": "#popin_tc_privacy_button_2",

--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -3110,7 +3110,7 @@
       },
       "cookies": {},
       "id": "1871561d-65f8-4972-8e8a-84fa9eb704b4",
-      "domains": ["cdiscount.com"]
+      "domains": ["cdiscount.com", "laposte.net", "laposte.fr"]
     },
     {
       "click": {

--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -6357,6 +6357,15 @@
       }
     },
     {
+      "id": "5D50AA8D-D00E-4A51-8D32-64965A0575CA",
+      "domains": ["quechoisir.org", "quechoisirensemble.fr"],
+      "click": {
+        "optIn": "#popin_tc_privacy_button_2",
+        "optOut": "#popin_tc_privacy_button",
+        "presence": "#tc-privacy-wrapper"
+      }
+    },
+    {
       "id": "3FD9FDA8-5F69-46C4-BA33-35FE3C804B4C",
       "domains": ["stepstone.de"],
       "click": {

--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -2741,6 +2741,7 @@
         "markiza.sk",
         "willhaben.at",
         "francetvinfo.fr",
+        "france.tv",
         "france24.com",
         "opodo.at",
         "opodo.ch",

--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -1924,6 +1924,15 @@
     },
     {
       "click": {
+        "optIn": "button.orejime-Notice-saveButton",
+        "optOut": "button.orejime-Notice-declineButton",
+        "presence": "div.orejime-Notice"
+      },
+      "id": "7293dc4c-1d3d-4236-84a6-3c5cb3def55a",
+      "domains": ["service-public.fr"]
+    },
+    {
+      "click": {
         "optIn": "button#popin_tc_privacy_button_2",
         "presence": "div#popin_tc_privacy_container_button"
       },

--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -1689,7 +1689,16 @@
         "leboncoin.fr",
         "boursorama.com",
         "boursobank.com",
-        "intermarche.com"
+        "intermarche.com",
+        "bricomarche.com",
+        "entrepot-du-bricolage.fr",
+        "lesnumeriques.com",
+        "seloger.com",
+        "societe.com",
+        "manomano.fr",
+        "pagesjaunes.fr",
+        "sncf-connect.com",
+        "largus.fr"
       ]
     },
     {
@@ -2727,7 +2736,9 @@
         "opodo.no",
         "opodo.pl",
         "opodo.pt",
-        "radiofrance.fr"
+        "radiofrance.fr",
+        "rfi.fr",
+        "blablacar.fr"
       ]
     },
     {

--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -5205,7 +5205,7 @@
     },
     {
       "id": "cc818b41-7b46-46d3-9b17-cf924cbe87d1",
-      "domains": ["arte.tv"],
+      "domains": ["arte.tv", "urssaf.fr"],
       "click": {
         "optIn": "#footer_tc_privacy_button",
         "optOut": "#footer_tc_privacy_button_2",

--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -6441,6 +6441,15 @@
         "optOut": "#cookieConsentRefuseButton",
         "presence": "#cookieConsentBanner"
       }
+    },
+    {
+      "id": "BC3582FC-C5FA-4743-85E8-7E46F67629AB",
+      "domains": ["rueducommerce.fr"],
+      "click": {
+        "optIn": "#rgpd-btn-index-accept",
+        "optOut": "#rgpd-btn-index-continue",
+        "presence": "#modalTpl"
+      }
     }
   ]
 }

--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -417,7 +417,13 @@
       },
       "cookies": {},
       "id": "2d821158-5945-4134-a078-56c6da4f678d",
-      "domains": ["fnac.be", "fnac.ch", "fnac.com", "fnac.pt"]
+      "domains": [
+        "fnac.be",
+        "fnac.ch",
+        "fnac.com",
+        "fnac.pt",
+        "mondialrelay.fr"
+      ]
     },
     {
       "click": {

--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -294,7 +294,8 @@
         "stackapps.com",
         "stackexchange.com",
         "stackoverflow.com",
-        "superuser.com"
+        "superuser.com",
+        "carrefour.fr"
       ]
     },
     {

--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -6423,6 +6423,15 @@
         "optOut": ".ei_lb_btnskip",
         "presence": "#cookieLB"
       }
+    },
+    {
+      "id": "4A767353-98B9-4284-857A-D98DC3ECDFE1",
+      "domains": ["ldlc.com", "ldlc.pro", "materiel.net"],
+      "click": {
+        "optIn": "#cookieConsentAcceptButton",
+        "optOut": "#cookieConsentRefuseButton",
+        "presence": "#cookieConsentBanner"
+      }
     }
   ]
 }

--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -418,10 +418,12 @@
       "cookies": {},
       "id": "2d821158-5945-4134-a078-56c6da4f678d",
       "domains": [
+        "e.leclerc",
         "fnac.be",
         "fnac.ch",
         "fnac.com",
         "fnac.pt",
+        "leclercdrive.fr",
         "mondialrelay.fr"
       ]
     },

--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -6324,7 +6324,7 @@
     },
     {
       "id": "98D89E26-F4B6-4C2D-BABF-4295B922E433",
-      "domains": ["fortuneo.fr", "lcl.fr"],
+      "domains": ["fortuneo.fr", "lcl.fr", "enedis.fr"],
       "click": {
         "optIn": "#popin_tc_privacy_button_3",
         "optOut": "#popin_tc_privacy_button_2",

--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -6381,7 +6381,7 @@
     },
     {
       "id": "17B1F270-F499-451C-AED5-5C737106F003",
-      "domains": ["ovhcloud.com"],
+      "domains": ["ovh.com", "ovhcloud.com", "ovhtelecom.fr"],
       "click": {
         "optIn": "#header_tc_privacy_button_3",
         "optOut": "#header_tc_privacy_button",

--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -6312,7 +6312,7 @@
     },
     {
       "id": "43ad2b6b-a57b-4f7a-9d76-e32e696ddc10",
-      "domains": ["dpd.com", "dpdgroup.com"],
+      "domains": ["dpd.com", "dpdgroup.com", "edf.fr", "totalenergies.fr"],
       "click": {
         "presence": "#tc-privacy-wrapper",
         "optOut": "#popin_tc_privacy_button_3",

--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -2757,7 +2757,8 @@
         "opodo.pt",
         "radiofrance.fr",
         "rfi.fr",
-        "blablacar.fr"
+        "blablacar.fr",
+        "6play.fr"
       ]
     },
     {

--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -6366,6 +6366,15 @@
       }
     },
     {
+      "id": "9022E9FE-2DC2-48DD-BE4A-EFA8A2C81E2B",
+      "domains": ["laredoute.fr"],
+      "click": {
+        "optIn": "#popin_tc_privacy_button_2",
+        "optOut": "#optout_link",
+        "presence": "#tc-privacy-wrapper"
+      }
+    },
+    {
       "id": "3FD9FDA8-5F69-46C4-BA33-35FE3C804B4C",
       "domains": ["stepstone.de"],
       "click": {

--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -6353,7 +6353,7 @@
     },
     {
       "id": "98D89E26-F4B6-4C2D-BABF-4295B922E433",
-      "domains": ["fortuneo.fr", "lcl.fr", "enedis.fr"],
+      "domains": ["fortuneo.fr", "lcl.fr", "enedis.fr", "tf1.fr"],
       "click": {
         "optIn": "#popin_tc_privacy_button_3",
         "optOut": "#popin_tc_privacy_button_2",

--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -3120,6 +3120,16 @@
     },
     {
       "click": {
+        "optIn": "button#footer_tc_privacy_button_3",
+        "optOut": "button#footer_tc_privacy_button_2",
+        "presence": "div#tc-privacy-wrapper"
+      },
+      "cookies": {},
+      "id": "6c1ebd2b-867a-40a5-8184-0ead733eae69",
+      "domains": ["labanquepostale.fr"]
+    },
+    {
+      "click": {
         "optIn": "button.css-fz9f1h",
         "presence": "div#qc-cmp2-container"
       },


### PR DESCRIPTION
I looked at the most visited sites in France on https://www.similarweb.com/top-websites/france/ and added a few of them and added a few others I came by.

* https://www.rfi.fr/
* https://www.entrepot-du-bricolage.fr/
* https://www.lesnumeriques.com/
* https://www.seloger.com/
* https://www.societe.com/
* https://www.manomano.fr/
* https://www.pagesjaunes.fr/
* https://www.sncf-connect.com/
* https://www.largus.fr/
* https://www.blablacar.fr/
* https://www.bricomarche.com/
* https://www.laposte.fr/
* https://www.laposte.net/accueil
* https://www.urssaf.fr/
* https://www.enedis.fr/
* https://www.mondialrelay.fr/
* https://www.edf.fr/
* https://www.totalenergies.fr/
* https://www.labanquepostale.fr/
* https://www.ldlc.com/
* https://www.ldlc.pro/
* https://www.materiel.net/
* https://www.service-public.fr/
* https://www.rueducommerce.fr/
* https://www.quechoisir.org/
* https://www.quechoisirensemble.fr/
* https://www.laredoute.fr/
* https://www.ovhcloud.com/fr/
* https://www.ovhtelecom.fr/
* https://www.ovh.com/
* https://www.e.leclerc/
* https://www.leclercdrive.fr/
* https://www.carrefour.fr/
* https://www.france.tv/
* https://www.tf1.fr/
* https://www.6play.fr/
* https://www.bouyguestelecom.fr/