### PR TITLE
Add rule for yazio.com

### DIFF
--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -6491,7 +6491,7 @@
         "presence": "#modalTpl"
       }
     },
-    {      
+    {
       "id": "B8CB497B-9E12-49A7-BA2A-B7842CAEDFC3",
       "domains": ["yazio.com"],
       "cookies": {

--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -6396,6 +6396,23 @@
         "optOut": ".ei_lb_btnskip",
         "presence": "#cookieLB"
       }
+    },
+    {
+      "id": "B8CB497B-9E12-49A7-BA2A-B7842CAEDFC3",
+      "domains": ["yazio.com"],
+      "cookies": {
+        "optOut": [
+          {
+            "name": "cc_cookie",
+            "value": "{\"level\":[\"necessary\"],\"revision\":0,\"data\":null,\"rfc_cookie\":false}"
+          }
+        ]
+      },
+      "click": {
+        "optIn": "#c-bns #c-p-bn",
+        "optOut": "#c-bns button.grey",
+        "presence": "#cm"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Example URL

`https://www.yazio.com/en`

## Screenshot

<img width="945" alt="Screenshot 2024-03-17 at 12 25 39" src="https://github.com/mozilla/cookie-banner-rules-list/assets/80652640/5788c2a9-c9da-4b27-85b6-d3a15332a0c6">

Tested on Firefox 124.0b9