### PR TITLE
Added support for localized variations of already supported websites

### DIFF
--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -5860,7 +5860,7 @@
     },
     {
       "id": "04e919eb-13c2-4b37-bf7f-888767888640",
-      "domains": ["endorfy.com", "krux.tech", "silentiumpc.com", "spcgear.com"],
+      "domains": ["krux.tech", "silentiumpc.com", "spcgear.com"],
       "cookies": {
         "optOut": [
           {
@@ -5872,6 +5872,29 @@
       "click": {
         "presence": "#cookie-law-info-bar",
         "optIn": "#wt-cli-accept-all-btn"
+      }
+    },
+    {
+      "id": "1be1e4d7-bcad-4fc8-a348-ae64af8bcac7",
+      "domains": ["endorfy.com"],
+      "cookies": {
+        "optIn": [
+          {
+            "name": "moove_gdpr_popup",
+            "value": "%7B%22strict%22%3A%221%22%2C%22thirdparty%22%3A%221%22%2C%22advanced%22%3A%221%22%7D"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "moove_gdpr_popup",
+            "value": "%7B%22strict%22%3A%221%22%2C%22thirdparty%22%3A%220%22%2C%22advanced%22%3A%220%22%7D"
+          }
+        ]
+      },
+      "click": {
+        "presence": "#moove_gdpr_cookie_info_bar",
+        "optOut": ".moove-gdpr-infobar-reject-btn",
+        "optIn": ".moove-gdpr-infobar-allow-all"
       }
     },
     {

--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -6203,7 +6203,7 @@
     },
     {
       "id": "04afc564-14b2-4c56-b72d-47a26e121f3b",
-      "domains": ["action.com"],
+      "domains": ["action.com", "gog.com"],
       "click": {
         "presence": "#cookiebanner",
         "optOut": "#CybotCookiebotDialogBodyLevelButtonLevelOptinDeclineAll",

--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -559,15 +559,6 @@
       }
     },
     {
-      "id": "9d29b82d-c438-4003-8573-54e1ad6fa031",
-      "domains": ["instagram.com"],
-      "click": {
-        "presence": "[role=\"dialog\"]",
-        "optOut": "[role=\"dialog\"] button + button",
-        "optIn": "[role=\"dialog\"] button:has(+ button)"
-      }
-    },
-    {
       "id": "c232eab8-f55a-436a-8033-478746d05d98",
       "domains": ["threads.net"],
       "cookies": {

--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -2769,7 +2769,8 @@
         "radiofrance.fr",
         "rfi.fr",
         "blablacar.fr",
-        "6play.fr"
+        "6play.fr",
+        "marianne.net"
       ]
     },
     {

--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -294,7 +294,8 @@
         "stackapps.com",
         "stackexchange.com",
         "stackoverflow.com",
-        "superuser.com"
+        "superuser.com",
+        "carrefour.fr"
       ]
     },
     {
@@ -417,7 +418,15 @@
       },
       "cookies": {},
       "id": "2d821158-5945-4134-a078-56c6da4f678d",
-      "domains": ["fnac.be", "fnac.ch", "fnac.com", "fnac.pt"]
+      "domains": [
+        "e.leclerc",
+        "fnac.be",
+        "fnac.ch",
+        "fnac.com",
+        "fnac.pt",
+        "leclercdrive.fr",
+        "mondialrelay.fr"
+      ]
     },
     {
       "click": {
@@ -1716,7 +1725,16 @@
         "leboncoin.fr",
         "boursorama.com",
         "boursobank.com",
-        "intermarche.com"
+        "intermarche.com",
+        "bricomarche.com",
+        "entrepot-du-bricolage.fr",
+        "lesnumeriques.com",
+        "seloger.com",
+        "societe.com",
+        "manomano.fr",
+        "pagesjaunes.fr",
+        "sncf-connect.com",
+        "largus.fr"
       ]
     },
     {
@@ -1933,6 +1951,15 @@
       },
       "id": "98fcb883-013a-4858-a181-28c87e399c42",
       "domains": ["belgium.be"]
+    },
+    {
+      "click": {
+        "optIn": "button.orejime-Notice-saveButton",
+        "optOut": "button.orejime-Notice-declineButton",
+        "presence": "div.orejime-Notice"
+      },
+      "id": "7293dc4c-1d3d-4236-84a6-3c5cb3def55a",
+      "domains": ["service-public.fr"]
     },
     {
       "click": {
@@ -2734,6 +2761,7 @@
         "markiza.sk",
         "willhaben.at",
         "francetvinfo.fr",
+        "france.tv",
         "france24.com",
         "opodo.at",
         "opodo.ch",
@@ -2747,7 +2775,10 @@
         "opodo.no",
         "opodo.pl",
         "opodo.pt",
-        "radiofrance.fr"
+        "radiofrance.fr",
+        "rfi.fr",
+        "blablacar.fr",
+        "6play.fr"
       ]
     },
     {
@@ -3119,7 +3150,17 @@
       },
       "cookies": {},
       "id": "1871561d-65f8-4972-8e8a-84fa9eb704b4",
-      "domains": ["cdiscount.com"]
+      "domains": ["cdiscount.com", "laposte.net", "laposte.fr"]
+    },
+    {
+      "click": {
+        "optIn": "button#footer_tc_privacy_button_3",
+        "optOut": "button#footer_tc_privacy_button_2",
+        "presence": "div#tc-privacy-wrapper"
+      },
+      "cookies": {},
+      "id": "6c1ebd2b-867a-40a5-8184-0ead733eae69",
+      "domains": ["labanquepostale.fr"]
     },
     {
       "click": {
@@ -5214,7 +5255,7 @@
     },
     {
       "id": "cc818b41-7b46-46d3-9b17-cf924cbe87d1",
-      "domains": ["arte.tv"],
+      "domains": ["arte.tv", "urssaf.fr"],
       "click": {
         "optIn": "#footer_tc_privacy_button",
         "optOut": "#footer_tc_privacy_button_2",
@@ -6297,7 +6338,7 @@
     },
     {
       "id": "43ad2b6b-a57b-4f7a-9d76-e32e696ddc10",
-      "domains": ["dpd.com", "dpdgroup.com"],
+      "domains": ["dpd.com", "dpdgroup.com", "edf.fr", "totalenergies.fr"],
       "click": {
         "presence": "#tc-privacy-wrapper",
         "optOut": "#popin_tc_privacy_button_3",
@@ -6315,10 +6356,43 @@
     },
     {
       "id": "98D89E26-F4B6-4C2D-BABF-4295B922E433",
-      "domains": ["fortuneo.fr", "lcl.fr"],
+      "domains": [
+        "bouyguestelecom.fr",
+        "enedis.fr",
+        "fortuneo.fr",
+        "lcl.fr",
+        "tf1.fr"
+      ],
       "click": {
         "optIn": "#popin_tc_privacy_button_3",
         "optOut": "#popin_tc_privacy_button_2",
+        "presence": "#tc-privacy-wrapper"
+      }
+    },
+    {
+      "id": "5D50AA8D-D00E-4A51-8D32-64965A0575CA",
+      "domains": ["quechoisir.org", "quechoisirensemble.fr"],
+      "click": {
+        "optIn": "#popin_tc_privacy_button_2",
+        "optOut": "#popin_tc_privacy_button",
+        "presence": "#tc-privacy-wrapper"
+      }
+    },
+    {
+      "id": "9022E9FE-2DC2-48DD-BE4A-EFA8A2C81E2B",
+      "domains": ["laredoute.fr"],
+      "click": {
+        "optIn": "#popin_tc_privacy_button_2",
+        "optOut": "#optout_link",
+        "presence": "#tc-privacy-wrapper"
+      }
+    },
+    {
+      "id": "17B1F270-F499-451C-AED5-5C737106F003",
+      "domains": ["ovh.com", "ovhcloud.com", "ovhtelecom.fr"],
+      "click": {
+        "optIn": "#header_tc_privacy_button_3",
+        "optOut": "#header_tc_privacy_button",
         "presence": "#tc-privacy-wrapper"
       }
     },
@@ -6397,6 +6471,24 @@
         "optIn": ".ei_btn_typ_validate",
         "optOut": ".ei_lb_btnskip",
         "presence": "#cookieLB"
+      }
+    },
+    {
+      "id": "4A767353-98B9-4284-857A-D98DC3ECDFE1",
+      "domains": ["ldlc.com", "ldlc.pro", "materiel.net"],
+      "click": {
+        "optIn": "#cookieConsentAcceptButton",
+        "optOut": "#cookieConsentRefuseButton",
+        "presence": "#cookieConsentBanner"
+      }
+    },
+    {
+      "id": "BC3582FC-C5FA-4743-85E8-7E46F67629AB",
+      "domains": ["rueducommerce.fr"],
+      "click": {
+        "optIn": "#rgpd-btn-index-accept",
+        "optOut": "#rgpd-btn-index-continue",
+        "presence": "#modalTpl"
       }
     }
   ]

--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -999,6 +999,7 @@
         "intersport.pl",
         "intersport.si",
         "issuu.com",
+        "telekom.ro",
         "voetbal24.be",
         "weforum.org"
       ]
@@ -2916,13 +2917,13 @@
       "domains": ["avanza.se"]
     },
     {
-      "click": {
-        "optIn": "button#consent_prompt_submit",
-        "presence": "div#__tealiumGDPRecModal"
-      },
-      "cookies": {},
       "id": "c40f3982-0372-4cdd-8aea-c150afd8328e",
-      "domains": ["post.ch"]
+      "domains": ["magenta.at", "post.ch", "rts.ch"],
+      "click": {
+        "presence": "#focus-lock-id",
+        "optOut": "[data-testid=\"uc-deny-all-button\"]",
+        "optIn": "[data-testid=\"uc-accept-all-button\"]"
+      }
     },
     {
       "click": {
@@ -3702,15 +3703,6 @@
       },
       "id": "8e9824be-3535-4d17-8e64-ae9628a0611d",
       "domains": ["capital.gr"]
-    },
-    {
-      "click": {
-        "optIn": "button#accept_all_cookies",
-        "presence": "section#cookie_consent"
-      },
-      "cookies": {},
-      "id": "80d51057-06fe-4469-be50-0438c9165020",
-      "domains": ["telekom.hu"]
     },
     {
       "click": {
@@ -5545,7 +5537,7 @@
     },
     {
       "id": "83ad4c2f-e59a-4295-a342-5db40fb81763",
-      "domains": ["decathlon.si"],
+      "domains": ["decathlon.si", "t-mobile.pl"],
       "cookies": {
         "optOut": [
           {
@@ -5649,13 +5641,123 @@
       "domains": ["bahn.de"]
     },
     {
+      "id": "2f9c701b-8b1f-4f44-82cc-e79d717e390f",
+      "domains": ["deutschetelekomitsolutions.sk"],
+      "cookies": {
+        "optOut": [
+          {
+            "name": "cookies",
+            "value": "%7B%22submitted%22%3A%222050-01-01T00%3A00%3A00Z%22%2C%22consent%22%3A%7B%22statistics%22%3Afalse%2C%22marketing%22%3Afalse%7D%7D"
+          }
+        ]
+      },
+      "click": {
+        "presence": "#modals",
+        "optOut": "#modals #decline-all",
+        "optIn": "#modals #accept-all"
+      }
+    },
+    {
+      "id": "8907164e-17d8-4d27-b0a3-edda59f53dbe",
+      "domains": [
+        "magentacloud.de",
+        "magentasport.de",
+        "t-systems.com",
+        "t-systems.jobs",
+        "telekom-hauptstadtrepraesentanz.com",
+        "telekom.com",
+        "telekom.de",
+        "telekom.jobs"
+      ],
+      "cookies": {
+        "optOut": [
+          {
+            "name": "CONSENTMGR",
+            "value": "c1:0%7Cc3:0%7Cc7:0%7Cts:2524608000000%7Cconsent:false"
+          }
+        ]
+      },
       "click": {
         "presence": "#__tealiumGDPRecModal",
-        "optIn": "#consentAcceptAll",
-        "optOut": "#rejectAll"
+        "optOut": "#rejectAll",
+        "optIn": "#consentAcceptAll"
+      }
+    },
+    {
+      "id": "2858c963-0a13-4c5b-b7e8-c3f9b79c5b8d",
+      "domains": ["telekom.mk"],
+      "cookies": {
+        "optOut": [
+          {
+            "name": "cookieConsent",
+            "value": "%7B%22strictlyNecessary%22%3Atrue%2C%22marketing%22%3Afalse%2C%22statistics%22%3Afalse%2C%22preferences%22%3Afalse%7D"
+          },
+          {
+            "name": "gdpr",
+            "value": "0"
+          }
+        ]
       },
-      "id": "8907164E-17D8-4D27-B0A3-EDDA59F53DBE",
-      "domains": ["telekom.com", "telekom.de"]
+      "click": {
+        "presence": "#cookiesModal",
+        "optOut": "#cookiesModal #required-cookies-btn",
+        "optIn": "#cookiesModal #all-cookies-btn"
+      }
+    },
+    {
+      "id": "7b4506b2-1c6f-4afc-ab5f-892331cabad3",
+      "domains": ["telekom.sk"],
+      "cookies": {
+        "optOut": [
+          {
+            "name": "cookieConsent",
+            "value": "%7B%22strictlyNecessary%22:true,%22preferences%22:false,%22marketing%22:false,%22statistics%22:false%7D"
+          },
+          {
+            "name": "cookieConsentVersion",
+            "value": "V3"
+          },
+          {
+            "name": "purpose_cookie",
+            "value": "1"
+          },
+          {
+            "name": "receiver_cookie",
+            "value": "14"
+          }
+        ]
+      },
+      "click": {
+        "presence": "#gdpr-component",
+        "optOut": "#rejectAllQuick",
+        "optIn": "#acceptAllQuick"
+      }
+    },
+    {
+      "id": "c7f03541-c93e-4939-a640-7c686d595986",
+      "domains": ["t-mobile.cz"],
+      "cookies": {
+        "optOut": [
+          {
+            "name": "cocos",
+            "value": "%7B%22funkcni%22%3Afalse%2C%22statisticke%22%3Afalse%2C%22reklamni%22%3Afalse%7D"
+          },
+          {
+            "name": "cookieConsent",
+            "value": "%7B%22preferences%22%3Afalse%2C%22statistics%22%3Afalse%2C%22marketing%22%3Afalse%7D"
+          },
+          {
+            "name": "corec",
+            "value": "%7B%22youtube%22%3Afalse%2C%22rtbhouse%22%3Afalse%2C%22google_recaptcha%22%3Atrue%2C%22foxentry_funkcni%22%3Afalse%2C%22tmobile_nezbytne%22%3Atrue%2C%22linkedin%22%3Afalse%2C%22medallia%22%3Afalse%2C%22tmobile_funkcni%22%3Afalse%2C%22tealium%22%3Afalse%2C%22adform%22%3Afalse%2C%22xaxis%22%3Afalse%2C%22twitter%22%3Afalse%2C%22appnexus%22%3Afalse%2C%22gemius%22%3Afalse%2C%22exponea%22%3Afalse%2C%22hotjar%22%3Afalse%2C%22tmobile_reklamni%22%3Afalse%2C%22facebook%22%3Afalse%2C%22inspectlet%22%3Afalse%2C%22cloudflare%22%3Afalse%2C%22google_ads%22%3Afalse%2C%22bing%22%3Afalse%2C%22foxentry_reklamni%22%3Afalse%2C%22clarity%22%3Afalse%2C%22seznam%22%3Afalse%2C%22tmobile_statisticke%22%3Afalse%2C%22google_analytics%22%3Afalse%2C%22rejectAllDate%22%3A%222024-03-28%22%7D"
+          }
+        ]
+      },
+      "click": {
+        "presence": "#gdpr-component",
+        "runContext": "child",
+        "optOut": "#rejectAllQuick",
+        "optIn": "#acceptAllQuick"
+      }
     },
     {
       "click": {
@@ -5866,16 +5968,6 @@
         "optOut": ".cky-btn.cky-btn-reject",
         "optIn": ".cky-btn.cky-btn-accept",
         "presence": ".cky-consent-bar"
-      },
-      "cookies": {}
-    },
-    {
-      "id": "9f5f0c06-5221-45b2-a174-7d70fd128eb3",
-      "domains": ["rts.ch"],
-      "click": {
-        "optOut": "[data-testid=\"uc-deny-all-button\"]",
-        "optIn": "[data-testid=\"uc-accept-all-button\"]",
-        "presence": "#usercentrics-root"
       },
       "cookies": {}
     },

--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -792,15 +792,42 @@
       "domains": ["bing.com"]
     },
     {
-      "click": {},
+      "id": "069f4d94-8031-4b83-b8f9-89752c5c1353",
+      "domains": [
+        "chollometro.com",
+        "dealabs.com",
+        "hotukdeals.com",
+        "mydealz.de",
+        "pepper.com",
+        "pepper.it",
+        "pepper.pl",
+        "preisjaeger.at"
+      ],
       "cookies": {
         "optOut": [
-          { "name": "cookie_policy_agreement", "value": "3" },
-          { "name": "dont-track", "value": "1" }
+          {
+            "name": "cookie_policy_agreement",
+            "value": "3"
+          },
+          {
+            "name": "dont-track",
+            "value": "1"
+          },
+          {
+            "name": "f_c",
+            "value": "0"
+          },
+          {
+            "name": "g_p",
+            "value": "0"
+          }
         ]
       },
-      "id": "069f4d94-8031-4b83-b8f9-89752c5c1353",
-      "domains": ["mydealz.de"]
+      "click": {
+        "presence": "[data-t=\"cookiesMessage\"]",
+        "optOut": "[data-t=\"continueWithoutAcceptingBtn\"]",
+        "optIn": "[data-t=\"acceptAllBtn\"]"
+      }
     },
     {
       "click": {},

--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -269,6 +269,15 @@
         "inpost.eu",
         "inpost.it",
         "intel.com",
+        "intersport.at",
+        "intersport.com",
+        "intersport.com.tr",
+        "intersport.cz",
+        "intersport.dk",
+        "intersport.es",
+        "intersport.hu",
+        "intersport.nl",
+        "intersport.sk",
         "kaufland.de",
         "lg.com",
         "lidl.co.uk",
@@ -975,6 +984,10 @@
         "intermarche.be",
         "intermarche.pl",
         "intermarche.pt",
+        "intersport.hr",
+        "intersport.it",
+        "intersport.pl",
+        "intersport.si",
         "issuu.com",
         "voetbal24.be",
         "weforum.org"
@@ -3285,13 +3298,13 @@
       "domains": ["metoffice.gov.uk", "footballmanager.com", "sigames.com"]
     },
     {
-      "click": {
-        "optIn": "button#kc-acceptAndHide",
-        "presence": "div#kconsent"
-      },
-      "cookies": {},
       "id": "282ff551-ce28-4b7f-9633-eaaa7ce89890",
-      "domains": ["k-ruoka.fi"]
+      "domains": ["intersport.fi", "k-ruoka.fi"],
+      "click": {
+        "presence": ".kc-onsent",
+        "optOut": "#kc-denyAndHide",
+        "optIn": "#kc-acceptAndHide"
+      }
     },
     {
       "click": {
@@ -6858,6 +6871,88 @@
         "presence": "#shopify-pc__banner",
         "optOut": "#shopify-pc__banner__btn-decline",
         "optIn": "#shopify-pc__banner__btn-accept"
+      }
+    },
+    {
+      "id": "9c762187-68bd-4d9b-b16c-014236082550",
+      "domains": ["intersport.be"],
+      "cookies": {
+        "optOut": [
+          {
+            "name": "CookieConsent",
+            "value": "{necessary:true%2Cpreferences:false%2Cstatistics:false%2Cmarketing:false%2Cmethod:%27explicit%27%2Cver:1%2Cutc:2524608000000%2Cregion:%27zz%27}"
+          }
+        ]
+      },
+      "click": {
+        "presence": "#CybotCookiebotDialog",
+        "optOut": "#CybotCookiebotDialogBodyButtonDecline",
+        "optIn": "#CybotCookiebotDialogBodyButtonAccept"
+      }
+    },
+    {
+      "id": "a8a9ddf7-1cf3-4252-b4f6-6d396e4c7ba7",
+      "domains": [
+        "intersport.bg",
+        "intersport.com.cy",
+        "intersport.gr",
+        "intersport.ro"
+      ],
+      "cookies": {
+        "optOut": [
+          {
+            "name": "ConsentChecked",
+            "value": "{\"userHasSetCookies\":true,\"functionalityCookies\":false,\"statisticCookies\":false,\"marketingCookies\":false}"
+          }
+        ]
+      },
+      "click": {
+        "presence": "#fancybox-container-1",
+        "optOut": ".js-decline",
+        "optIn": ".js-accept"
+      }
+    },
+    {
+      "id": "de176046-8be7-4876-8332-0559dfd0b70b",
+      "domains": ["intersport.de"],
+      "click": {
+        "presence": ".cookie-banner",
+        "optOut": ".js--cookie-banner-save-required-settings",
+        "optIn": ".js--cookie-banner-accept"
+      }
+    },
+    {
+      "id": "1450d6da-220a-42dd-b523-1771343cbd90",
+      "domains": ["intersport.fo"],
+      "cookies": {
+        "optOut": [
+          {
+            "name": "ConsentV2",
+            "value": "[%22necessary%22]"
+          }
+        ]
+      },
+      "click": {
+        "presence": "#cookieConsentModal",
+        "optOut": "#acceptNecessaryCookiesBtn",
+        "optIn": "#acceptAllCookiesBtn"
+      }
+    },
+    {
+      "id": "6fdb72ae-429c-49ad-87d3-4ff2675e5d29",
+      "domains": ["intersport.mk"],
+      "cookies": {
+        "optOut": [
+          {
+            "name": "site_cookie_info_i",
+            "value": "2"
+          }
+        ]
+      },
+      "click": {
+        "presence": "#modal-cookie-info",
+        "optOut": ".no-agree > a",
+        "optIn": ".cookie-agree"
       }
     }
   ]

--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -300,6 +300,14 @@
         "soundcloud.com",
         "trello.com",
         "unrealengine.com",
+        "vodafone.al",
+        "vodafone.co.uk",
+        "vodafone.es",
+        "vodafone.gr",
+        "vodafone.hu",
+        "vodafone.ie",
+        "vodafone.nl",
+        "vodafone.ro",
         "askubuntu.com",
         "mathoverflow.net",
         "serverfault.com",
@@ -419,7 +427,9 @@
         "slack.com",
         "thawte.com",
         "ui.com",
-        "uisp.com"
+        "uisp.com",
+        "vodafone.com.tr",
+        "vodafone.it"
       ]
     },
     {
@@ -1603,14 +1613,84 @@
       "domains": ["gsis.gr"]
     },
     {
-      "click": {
-        "optIn": "button.t_cm_ec_continue_button",
-        "optOut": "button.t_cm_ec_reject_button",
-        "presence": "div.t_cm_ec_modal_footer"
-      },
-      "cookies": {},
       "id": "a4cb7b9f-0a47-4fc8-ac4c-5e9d0d598531",
-      "domains": ["vodafone.com"]
+      "domains": ["vodafone.com"],
+      "cookies": {
+        "optOut": [
+          {
+            "name": "CONSENTMGR",
+            "value": "c1:0%7Cc2:0%7Cc3:0%7Cc4:0%7Cc5:0%7Cc6:0%7Cc7:0%7Cc8:0%7Cc9:0%7Cc10:0%7Cc11:0%7Cc12:0%7Cc13:0%7Cc14:0%7Cc15:0%7Cts:2524608000000%7Cconsent:false"
+          }
+        ]
+      },
+      "click": {
+        "presence": "#__tealiumGDPRecModal",
+        "optOut": ".t_cm_ec_reject_button",
+        "optIn": ".t_cm_ec_continue_button"
+      }
+    },
+    {
+      "id": "ba7bde95-93ff-43fd-845f-b8a396b46480",
+      "domains": ["vodafone.cz"],
+      "cookies": {
+        "optOut": [
+          {
+            "name": "vfconsents",
+            "value": "\"cvx:5|vt:2524608000000|vn:1|ci:1|funa:o|mktg:o|cond:1|dldt:2524608000000|cvd:5|cvu:5|cdd:2524608000000|vind:1\""
+          }
+        ]
+      },
+      "click": {
+        "presence": ".vfcc__overlay",
+        "optOut": "[value=\"saveNecessarily\"]",
+        "optIn": "[value=\"allowAll\"]"
+      }
+    },
+    {
+      "id": "b85f7d67-d6d4-40ee-8472-a32b6cd01e0e",
+      "domains": ["vodafone.de"],
+      "click": {
+        "presence": "#dip-consent",
+        "optOut": "#dip-consent-summary-reject-all",
+        "optIn": "#dip-consent-summary-accept-all"
+      }
+    },
+    {
+      "id": "723c6f57-2399-4a6c-bd5e-83650d2db861",
+      "domains": ["vodafone.pf"],
+      "cookies": {
+        "optOut": [
+          {
+            "name": "cpnb_cookiesSettings",
+            "value": "%7B%22required-cookies%22%3A1%2C%22analytical-cookies%22%3A0%2C%22social-media-cookies%22%3A0%2C%22targeted-advertising-cookies%22%3A0%7D"
+          },
+          {
+            "name": "cpnbCookiesDeclined",
+            "value": "1"
+          }
+        ]
+      },
+      "click": {
+        "presence": "#cpnb",
+        "optOut": "#cpnb-decline-btn",
+        "optIn": "#cpnb-accept-btn"
+      }
+    },
+    {
+      "id": "522a2d72-8131-406e-b058-b27ec07808fc",
+      "domains": ["vodafone.pt"],
+      "cookies": {
+        "optOut": [
+          {
+            "name": "OPTOUTCONSENT",
+            "value": "1:1&2:0&3:0&4:0"
+          }
+        ]
+      },
+      "click": {
+        "presence": "#cookiesModal",
+        "optIn": ".ebu-cookies-layer__modal-buttons > .confirm"
+      }
     },
     {
       "click": {
@@ -4412,14 +4492,13 @@
       "domains": ["17track.net"]
     },
     {
+      "id": "305b6c0d-5b66-4b3f-bf0f-fb85db21fe60",
+      "domains": ["cookiehub.com", "semrush.com", "vodafone.is"],
       "click": {
-        "optIn": "button.ch2-allow-all-btn",
-        "optOut": "button.ch2-deny-all-btn",
-        "presence": "div.ch2-container"
-      },
-      "cookies": {},
-      "id": "2f54e492-0f33-4496-ab08-99af50bf6f22",
-      "domains": ["semrush.com"]
+        "presence": ".ch2-dialog",
+        "optOut": ".ch2-deny-all-btn",
+        "optIn": ".ch2-allow-all-btn"
+      }
     },
     {
       "click": { "optIn": "a.cc-dismiss", "presence": "div.cc-window" },
@@ -5171,14 +5250,6 @@
       "domains": ["se.pl"]
     },
     {
-      "click": {},
-      "cookies": {
-        "optOut": [{ "name": "OPTOUTCONSENT", "value": "1:1&2:0&3:0&4:0" }]
-      },
-      "id": "522a2d72-8131-406e-b058-b27ec07808fc",
-      "domains": ["vodafone.pt"]
-    },
-    {
       "click": {
         "optIn": "div#cookiescript_accept",
         "optOut": "div#cookiescript_reject ",
@@ -5576,16 +5647,6 @@
       },
       "id": "D4AD5843-DDBD-4D93-BFBA-F53DD8B53111",
       "domains": ["bahn.de"]
-    },
-    {
-      "cookies": {},
-      "click": {
-        "presence": "#dip-consent",
-        "optIn": "#dip-consent-summary-accept-all",
-        "optOut": "#dip-consent-summary-reject-all"
-      },
-      "id": "B85F7D67-D6D4-40EE-8472-A32B6CD01E0E",
-      "domains": ["vodafone.de"]
     },
     {
       "click": {

--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -6383,6 +6383,15 @@
         "optOut": "#cookieBtnContinue",
         "presence": ".cookie_consent_withings"
       }
+    },
+    {
+      "id": "1B309A53-16B4-4BBE-91F4-86260A15B8E7",
+      "domains": ["creditmutuel.fr"],
+      "click": {
+        "optIn": ".ei_btn_typ_validate",
+        "optOut": ".ei_lb_btnskip",
+        "presence": "#cookieLB"
+      }
     }
   ]
 }

--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -2053,7 +2053,7 @@
         ]
       },
       "id": "850ca0e7-372f-4c9f-bfbd-76d38a076cf7",
-      "domains": ["credit-agricole.fr", "sparkasse.at"]
+      "domains": ["sparkasse.at"]
     },
     {
       "click": {
@@ -6670,6 +6670,98 @@
             "value": "1"
           }
         ]
+      }
+    },
+    {
+      "id": "1f0a3536-5b09-426a-b6e6-b902c556cb8a",
+      "domains": ["credit-agricole.com"],
+      "cookies": {
+        "optOut": [
+          {
+            "name": "cookie_manager",
+            "value": "!atinternet=false!recaptcha=false!addthis=false!linkedin=false!twitter=false!ezplatform=true!youtube=false!hidebanner=true"
+          }
+        ]
+      },
+      "click": {
+        "presence": "#tarteaucitronAlertBig",
+        "optOut": ".deny",
+        "optIn": ".accept"
+      }
+    },
+    {
+      "id": "1e12c729-34ff-4aa5-9317-d19309affd2c",
+      "domains": ["credit-agricole.de"],
+      "cookies": {
+        "optOut": [
+          {
+            "name": "cookie_manager",
+            "value": "!atinternet=false!recaptcha=false!addthis=false!twitter=false!ezplatform=true!youtube=false!hidebanner=true"
+          }
+        ]
+      },
+      "click": {
+        "presence": "#tarteaucitronWelcome",
+        "optOut": ".deny",
+        "optIn": ".allow"
+      }
+    },
+    {
+      "id": "f643be2a-b805-4ab0-9e67-929419e5c7c7",
+      "domains": ["credit-agricole.fr"],
+      "cookies": {
+        "optOut": [
+          {
+            "name": "TC_PRIVACY",
+            "value": "1%40006%7C86%7C3315%40%40%402524608000000%2C2524608000000%2C2524608000000%40"
+          }
+        ]
+      },
+      "click": {
+        "presence": "#tc-privacy-wrapper",
+        "optOut": "#popin_tc_privacy_button_3",
+        "optIn": "#popin_tc_privacy_button_2"
+      }
+    },
+    {
+      "id": "1944a25e-6f16-434d-8c59-0493ba587fe7",
+      "domains": ["credit-agricole.it"],
+      "cookies": {
+        "optOut": [
+          {
+            "name": "cookie_manager_cookie_marketing_enabled",
+            "value": "false"
+          },
+          {
+            "name": "cookie_manager_cookie_necessary_enabled",
+            "value": "true"
+          },
+          {
+            "name": "cookie_manager_cookie_statistic_enabled",
+            "value": "false"
+          },
+          {
+            "name": "cookie_manager_policy_accepted",
+            "value": "true"
+          }
+        ]
+      }
+    },
+    {
+      "id": "5050fb9c-fd8a-44c2-817c-23d95f494190",
+      "domains": ["credit-agricole.pl"],
+      "cookies": {
+        "optOut": [
+          {
+            "name": "ppms_privacy_7bd68a14-fbc6-44f1-9d8b-1cf0cf5eb0bb",
+            "value": "{%22consents%22:{%22analytics%22:{%22status%22:0%2C%22updatedAt%22:%222050-01-01T00:00:00.000Z%22}%2C%22ab_testing_and_personalization%22:{%22status%22:0%2C%22updatedAt%22:%222050-01-01T00:00:00.000Z%22}%2C%22remarketing%22:{%22status%22:0%2C%22updatedAt%22:%222050-01-01T00:00:00.000Z%22}}%2C%22domain%22:{%22normalized%22:%22credit-agricole.pl%22%2C%22isWildcard%22:true%2C%22pattern%22:%22*.credit-agricole.pl%22}}"
+          }
+        ]
+      },
+      "click": {
+        "presence": "#ppms_cm_popup_overlay",
+        "optOut": "#ppms_cm_reject-all",
+        "optIn": "#ppms_cm_agree-to-all"
       }
     }
   ]

--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -1760,6 +1760,7 @@
         "subito.it",
         "hasznaltauto.hu",
         "zdnet.de",
+        "zdnet.fr",
         "intersport.fr",
         "decathlon.fr",
         "leboncoin.fr",

--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -550,6 +550,33 @@
       }
     },
     {
+      "id": "9d29b82d-c438-4003-8573-54e1ad6fa031",
+      "domains": ["instagram.com"],
+      "click": {
+        "presence": "[role=\"dialog\"]",
+        "optOut": "[role=\"dialog\"] button + button",
+        "optIn": "[role=\"dialog\"] button:has(+ button)"
+      }
+    },
+    {
+      "id": "c232eab8-f55a-436a-8033-478746d05d98",
+      "domains": ["threads.net"],
+      "cookies": {
+        "optIn": [
+          {
+            "name": "cb",
+            "value": "1_2055_07_11_"
+          }
+        ],
+        "optOut": [
+          {
+            "name": "cb",
+            "value": "1_2055_07_11_2-3"
+          }
+        ]
+      }
+    },
+    {
       "cookies": {
         "optOut": [
           {
@@ -5200,24 +5227,6 @@
         "optOut": "#footer_tc_privacy_button_2",
         "presence": ".tc-privacy-wrapper.tc-privacy-override.tc-privacy-wrapper"
       }
-    },
-    {
-      "cookies": {
-        "optOut": [
-          {
-            "name": "cb",
-            "value": "1_2055_07_11_2-3"
-          }
-        ],
-        "optIn": [
-          {
-            "name": "cb",
-            "value": "1_2055_07_11_"
-          }
-        ]
-      },
-      "id": "C232EAB8-F55A-436A-8033-478746D05D98",
-      "domains": ["threads.net"]
     },
     {
       "id": "05157ed1-12c2-4f84-9dff-718fae5bc096",

--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -1885,6 +1885,7 @@
         "lesechos.fr",
         "numerama.com",
         "jofogas.hu",
+        "orange.com",
         "orange.fr",
         "meteofrance.com",
         "subito.it",
@@ -1919,6 +1920,7 @@
         "decathlon.mt",
         "decathlon.nl",
         "decathlon.yoga",
+        "orange.pl",
         "quechua.fr"
       ],
       "cookies": {
@@ -1937,7 +1939,13 @@
     },
     {
       "id": "5da98b86-9a16-47ec-8607-046744d93396",
-      "domains": ["decathlon.cz", "decathlon.it", "hnonline.sk", "orange.sk"],
+      "domains": [
+        "decathlon.cz",
+        "decathlon.it",
+        "hnonline.sk",
+        "orange.md",
+        "orange.sk"
+      ],
       "cookies": {
         "optOut": [
           {
@@ -2999,6 +3007,23 @@
         "optOut": [
           {
             "name": "euconsent-v2",
+            "value": "CXgyJwAXgyJwAAHABBENAtEgAAAAAAAAAAAAAAAAAAAA.YAAAAAAAAAAA"
+          }
+        ]
+      },
+      "click": {
+        "presence": "#didomi-popup",
+        "optOut": "#didomi-notice-disagree-button",
+        "optIn": "#didomi-notice-agree-button"
+      }
+    },
+    {
+      "id": "49719e34-a29a-4604-ae3c-b9835e286473",
+      "domains": ["orange-business.com"],
+      "cookies": {
+        "optOut": [
+          {
+            "name": "consentiab",
             "value": "CXgyJwAXgyJwAAHABBENAtEgAAAAAAAAAAAAAAAAAAAA.YAAAAAAAAAAA"
           }
         ]
@@ -5520,6 +5545,7 @@
         "decathlon.lt",
         "decathlon.lv",
         "decathlon.se",
+        "orange.lu",
         "reverso.net"
       ],
       "cookies": {
@@ -7106,6 +7132,68 @@
         "presence": "#modal-cookie-info",
         "optOut": ".no-agree > a",
         "optIn": ".cookie-agree"
+      }
+    },
+    {
+      "id": "2172b091-8b03-4f66-b20c-08c14e21c0aa",
+      "domains": ["orange.be"],
+      "cookies": {
+        "optOut": [
+          {
+            "name": "CONSENTMGR",
+            "value": "c1:0%7Cc6:0%7Cc9:0%7Cts:2524608000000%7Cconsent:false"
+          }
+        ]
+      },
+      "click": {
+        "presence": "#__tealiumGDPRecModal",
+        "optIn": "#consent_prompt_submit"
+      }
+    },
+    {
+      "id": "1626f70d-7761-467c-b3ed-56e324786902",
+      "domains": ["orange.es"],
+      "cookies": {
+        "optOut": [
+          {
+            "name": "CONSENTMGR",
+            "value": "c1:0%7Cc2:0%7Cc3:0%7Cc4:0%7Cc5:0%7Cc6:0%7Cc7:0%7Cc8:0%7Cc9:0%7Cc10:0%7Cc11:0%7Cc12:0%7Cc13:0%7Cc14:0%7Cc15:0%7Cts:2524608000000%7Cconsent:false"
+          }
+        ]
+      },
+      "click": {
+        "presence": "#__tealiumGDPRecModal",
+        "optOut": "#consent_optout",
+        "optIn": "#consent_optin"
+      }
+    },
+    {
+      "id": "2e026e27-1356-40c8-a25c-24fbe4bf8af4",
+      "domains": ["orange.jobs"],
+      "cookies": {
+        "optOut": [
+          {
+            "name": "consent",
+            "value": "bypass"
+          }
+        ]
+      },
+      "click": {
+        "presence": ".fancybox-type-html",
+        "optOut": ".js-consent-bypass-button",
+        "optIn": ".js-consent-all-submit"
+      }
+    },
+    {
+      "id": "24350444-6b01-46a5-b8a4-99f4d417f08f",
+      "domains": ["orange.sn"],
+      "cookies": {
+        "optOut": [
+          {
+            "name": "orange_cookieconsent_dismissed",
+            "value": "no"
+          }
+        ]
       }
     }
   ]

--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -6045,28 +6045,7 @@
     },
     {
       "id": "3c0e4924-29ee-4d9a-99ec-e4805a7ffed9",
-      "domains": [
-        "verbatim-europe.co.uk",
-        "verbatim-europe.cz",
-        "verbatim.ae",
-        "verbatim.bg",
-        "verbatim.co.il",
-        "verbatim.com.hr",
-        "verbatim.com.pt",
-        "verbatim.com.tr",
-        "verbatim.de",
-        "verbatim.dk",
-        "verbatim.es",
-        "verbatim.fi",
-        "verbatim.fr",
-        "verbatim.gr",
-        "verbatim.hu",
-        "verbatim.it",
-        "verbatim.net.pl",
-        "verbatim.ro",
-        "verbatim.ru",
-        "verbatim.se"
-      ],
+      "domains": ["verbatim.co.il"],
       "cookies": {
         "optIn": [
           {
@@ -6158,7 +6137,7 @@
     },
     {
       "id": "f1849b07-95e8-4ae0-a99d-24df5abbb3cb",
-      "domains": ["dell.com", "delltechnologies.com"],
+      "domains": ["dell.com", "dell.eu", "delltechnologies.com"],
       "click": {
         "presence": ".cc-window",
         "optOut": ".cc-dismiss",
@@ -6169,7 +6148,6 @@
       "id": "92361e84-664e-46b3-ae55-95bc185dc88e",
       "domains": [
         "adoptium.net",
-        "eclipse-ee4j.github.io",
         "eclipse.dev",
         "eclipse.org",
         "glassfish.org",
@@ -6312,12 +6290,12 @@
       }
     },
     {
-      "id": "43AD2B6B-A57B-4F7A-9D76-E32E696DDC10",
-      "domains": ["dpd.com"],
+      "id": "43ad2b6b-a57b-4f7a-9d76-e32e696ddc10",
+      "domains": ["dpd.com", "dpdgroup.com"],
       "click": {
-        "optIn": "#popin_tc_privacy_button",
+        "presence": "#tc-privacy-wrapper",
         "optOut": "#popin_tc_privacy_button_3",
-        "presence": "#tc-privacy-wrapper"
+        "optIn": "#popin_tc_privacy_button"
       }
     },
     {

--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -6308,6 +6308,15 @@
       }
     },
     {
+      "id": "98D89E26-F4B6-4C2D-BABF-4295B922E433",
+      "domains": ["fortuneo.fr", "lcl.fr"],
+      "click": {
+        "optIn": "#popin_tc_privacy_button_3",
+        "optOut": "#popin_tc_privacy_button_2",
+        "presence": "#tc-privacy-wrapper"
+      }
+    },
+    {
       "id": "3FD9FDA8-5F69-46C4-BA33-35FE3C804B4C",
       "domains": ["stepstone.de"],
       "click": {

--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -411,6 +411,16 @@
     },
     {
       "click": {
+        "optIn": "button#onetrust-accept-btn-handler",
+        "optOut": "button.onetrust-close-btn-handler",
+        "presence": "div#onetrust-consent-sdk"
+      },
+      "cookies": {},
+      "id": "2d821158-5945-4134-a078-56c6da4f678d",
+      "domains": ["fnac.be", "fnac.ch", "fnac.com", "fnac.pt"]
+    },
+    {
+      "click": {
         "optIn": ".qc-cmp2-summary-buttons > :nth-child(3)",
         "optOut": ".qc-cmp2-summary-buttons > :nth-child(2)",
         "presence": "#qc-cmp2-container"

--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -5408,11 +5408,16 @@
       "domains": ["fandom.com"]
     },
     {
-      "click": {
-        "presence": "#mms-consent-portal-container",
-        "optOut": "button[data-test=\"pwa-consent-layer-deny-all\"]",
-        "optIn": "button[data-test=\"pwa-consent-layer-accept-all\"]"
-      },
+      "id": "2a2b8102-d276-4ece-afbd-005e8e917d18",
+      "domains": [
+        "mediamarkt.at",
+        "mediamarkt.be",
+        "mediamarkt.de",
+        "mediamarkt.es",
+        "mediamarkt.nl",
+        "mediamarkt.pl",
+        "saturn.de"
+      ],
       "cookies": {
         "optOut": [
           {
@@ -5421,8 +5426,28 @@
           }
         ]
       },
-      "id": "2A2B8102-D276-4ECE-AFBD-005E8E917D18",
-      "domains": ["mediamarkt.de", "saturn.de"]
+      "click": {
+        "presence": "[data-test=\"mms-privacy-layer\"]",
+        "optOut": "[data-test=\"pwa-consent-layer-deny-all\"]",
+        "optIn": "#pwa-consent-layer-accept-all-button"
+      }
+    },
+    {
+      "id": "6f85da65-e44e-4d58-b87c-3e31861de3e0",
+      "domains": ["mediamarktsaturn.com"],
+      "cookies": {
+        "optOut": [
+          {
+            "name": "cookiesjsr",
+            "value": "%7B%22functional%22%3Afalse%2C%22recaptcha%22%3Afalse%2C%22video%22%3Afalse%7D"
+          }
+        ]
+      },
+      "click": {
+        "presence": ".cookiesjsr-banner",
+        "optOut": ".denyAll",
+        "optIn": ".allowAll"
+      }
     },
     {
       "cookies": {

--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -1923,14 +1923,7 @@
         "orange.pl",
         "quechua.fr"
       ],
-      "cookies": {
-        "optOut": [
-          {
-            "name": "euconsent-v2",
-            "value": "CXgyJwAXgyJwAAHABBENAtEgAAAAAAAAAAAAAAAAAAAA.YAAAAAAAAAAA"
-          }
-        ]
-      },
+      "cookies": {},
       "click": {
         "presence": "#didomi-popup",
         "optOut": ".didomi-continue-without-agreeing",
@@ -1946,14 +1939,7 @@
         "orange.md",
         "orange.sk"
       ],
-      "cookies": {
-        "optOut": [
-          {
-            "name": "euconsent-v2",
-            "value": "CXgyJwAXgyJwAAHABBENAtEgAAAAAAAAAAAAAAAAAAAA.YAAAAAAAAAAA"
-          }
-        ]
-      },
+      "cookies": {},
       "click": {
         "presence": "#didomi-notice",
         "optOut": ".didomi-continue-without-agreeing",
@@ -3003,14 +2989,7 @@
         "decathlon.ro",
         "decathlon.sk"
       ],
-      "cookies": {
-        "optOut": [
-          {
-            "name": "euconsent-v2",
-            "value": "CXgyJwAXgyJwAAHABBENAtEgAAAAAAAAAAAAAAAAAAAA.YAAAAAAAAAAA"
-          }
-        ]
-      },
+      "cookies": {},
       "click": {
         "presence": "#didomi-popup",
         "optOut": "#didomi-notice-disagree-button",
@@ -3020,14 +2999,7 @@
     {
       "id": "49719e34-a29a-4604-ae3c-b9835e286473",
       "domains": ["orange-business.com"],
-      "cookies": {
-        "optOut": [
-          {
-            "name": "consentiab",
-            "value": "CXgyJwAXgyJwAAHABBENAtEgAAAAAAAAAAAAAAAAAAAA.YAAAAAAAAAAA"
-          }
-        ]
-      },
+      "cookies": {},
       "click": {
         "presence": "#didomi-popup",
         "optOut": "#didomi-notice-disagree-button",
@@ -3037,14 +3009,7 @@
     {
       "id": "e4b0998b-a54c-458d-935b-6ec957175711",
       "domains": ["decathlon.ee"],
-      "cookies": {
-        "optOut": [
-          {
-            "name": "euconsent-v2",
-            "value": "CXgyJwAXgyJwAAHABBENAtEgAAAAAAAAAAAAAAAAAAAA.YAAAAAAAAAAA"
-          }
-        ]
-      },
+      "cookies": {},
       "click": {
         "presence": "#didomi-popup",
         "optOut": "#didomi-notice-x-button",
@@ -5548,14 +5513,7 @@
         "orange.lu",
         "reverso.net"
       ],
-      "cookies": {
-        "optOut": [
-          {
-            "name": "euconsent-v2",
-            "value": "CXgyJwAXgyJwAAHABBENAtEgAAAAAAAAAAAAAAAAAAAA.YAAAAAAAAAAA"
-          }
-        ]
-      },
+      "cookies": {},
       "click": {
         "presence": "#didomi-popup",
         "optIn": "#didomi-notice-agree-button"
@@ -5564,14 +5522,7 @@
     {
       "id": "83ad4c2f-e59a-4295-a342-5db40fb81763",
       "domains": ["decathlon.si", "t-mobile.pl"],
-      "cookies": {
-        "optOut": [
-          {
-            "name": "euconsent-v2",
-            "value": "CXgyJwAXgyJwAAHABBENAtEgAAAAAAAAAAAAAAAAAAAA.YAAAAAAAAAAA"
-          }
-        ]
-      },
+      "cookies": {},
       "click": {
         "presence": "#didomi-notice",
         "optIn": "#didomi-notice-agree-button"
@@ -7029,14 +6980,7 @@
     {
       "id": "5050fb9c-fd8a-44c2-817c-23d95f494190",
       "domains": ["credit-agricole.pl"],
-      "cookies": {
-        "optOut": [
-          {
-            "name": "ppms_privacy_7bd68a14-fbc6-44f1-9d8b-1cf0cf5eb0bb",
-            "value": "{%22consents%22:{%22analytics%22:{%22status%22:0%2C%22updatedAt%22:%222050-01-01T00:00:00.000Z%22}%2C%22ab_testing_and_personalization%22:{%22status%22:0%2C%22updatedAt%22:%222050-01-01T00:00:00.000Z%22}%2C%22remarketing%22:{%22status%22:0%2C%22updatedAt%22:%222050-01-01T00:00:00.000Z%22}}%2C%22domain%22:{%22normalized%22:%22credit-agricole.pl%22%2C%22isWildcard%22:true%2C%22pattern%22:%22*.credit-agricole.pl%22}}"
-          }
-        ]
-      },
+      "cookies": {},
       "click": {
         "presence": "#ppms_cm_popup_overlay",
         "optOut": "#ppms_cm_reject-all",

--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -3312,28 +3312,39 @@
       "domains": ["uio.no"]
     },
     {
-      "click": {
-        "optIn": "button#uc-btn-accept-banner",
-        "optOut": "button#uc-btn-deny-banner",
-        "presence": "div#uc-banner-modal"
-      },
-      "cookies": {},
       "id": "3203ac4e-2454-4022-90fb-d4f51467ce20",
       "domains": [
-        "zalando.ch",
-        "zalando.dk",
-        "zalando.be",
-        "zalando.de",
         "zalando.at",
+        "zalando.be",
+        "zalando.ch",
         "zalando.co.uk",
         "zalando.com",
         "zalando.cz",
+        "zalando.de",
+        "zalando.dk",
         "zalando.ee",
         "zalando.es",
         "zalando.fi",
         "zalando.fr",
-        "zalando.hr"
-      ]
+        "zalando.hr",
+        "zalando.hu",
+        "zalando.ie",
+        "zalando.it",
+        "zalando.lt",
+        "zalando.lv",
+        "zalando.nl",
+        "zalando.no",
+        "zalando.pl",
+        "zalando.ro",
+        "zalando.se",
+        "zalando.si",
+        "zalando.sk"
+      ],
+      "click": {
+        "presence": "#uc-main-banner",
+        "optOut": "#uc-btn-deny-banner",
+        "optIn": "#uc-btn-accept-banner"
+      }
     },
     {
       "click": { "optIn": "a.cookies-agree", "presence": "div.cookies-notify" },

--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -2347,14 +2347,7 @@
         "optOut": "button#CybotCookiebotDialogBodyButtonDecline",
         "presence": "div#CybotCookiebotDialog"
       },
-      "cookies": {
-        "optOut": [
-          {
-            "name": "CookieConsent",
-            "value": "{stamp:%277wlvZfVgG/Pfkj1y6Hfoz636NePkdUWVOV+lQLpJefS1O2ny+RqIdg==%27%2Cnecessary:true%2Cpreferences:false%2Cstatistics:false%2Cmarketing:false%2Cmethod:%27explicit%27%2Cver:5%2Cutc:1699462925195%2Ciab2:%27CP07BsAP07BsACGABBENDeCgAAAAAH_AAAAAAAAS4gGgAgABkAEQAJ4AbwA_AEWAJ2AYoBMgC8wGCAS4AAAA.YAAAAAAAAAAA%27%2Cgacm:%271~%27%2Cregion:%27de%27}"
-          }
-        ]
-      },
+      "cookies": {},
       "id": "1006f951-cd51-47cc-9527-5036cef4b85a",
       "domains": ["politiken.dk"]
     },

--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -971,7 +971,14 @@
       },
       "cookies": {},
       "id": "019c0709-e9ef-4b0d-94bf-958d251a51b5",
-      "domains": ["issuu.com", "dobrenoviny.sk", "voetbal24.be", "weforum.org"]
+      "domains": [
+        "intermarche.be",
+        "intermarche.pl",
+        "intermarche.pt",
+        "issuu.com",
+        "voetbal24.be",
+        "weforum.org"
+      ]
     },
     {
       "click": {

--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -1317,7 +1317,8 @@
         "denik.cz",
         "csfd.cz",
         "hn.cz",
-        "moviepilot.de"
+        "moviepilot.de",
+        "chip.cz"
       ]
     },
     {
@@ -4330,7 +4331,9 @@
         "computerbild.de",
         "t-online.de",
         "wetteronline.de",
+        "chip-kiosk.de",
         "chip.de",
+        "chip.info",
         "n-tv.de",
         "newsnow.co.uk",
         "telegraph.co.uk",

--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -6490,6 +6490,23 @@
         "optOut": "#rgpd-btn-index-continue",
         "presence": "#modalTpl"
       }
+    },
+    {
+      "id": "B8CB497B-9E12-49A7-BA2A-B7842CAEDFC3",
+      "domains": ["yazio.com"],
+      "cookies": {
+        "optOut": [
+          {
+            "name": "cc_cookie",
+            "value": "{\"level\":[\"necessary\"],\"revision\":0,\"data\":null,\"rfc_cookie\":false}"
+          }
+        ]
+      },
+      "click": {
+        "optIn": "#c-bns #c-p-bn",
+        "optOut": "#c-bns button.grey",
+        "presence": "#cm"
+      }
     }
   ]
 }

--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -4352,7 +4352,13 @@
         "runContext": "child"
       },
       "cookies": {},
-      "domains": ["aktuality.sk", "sky.it", "azet.sk", "bloomberg.com"],
+      "domains": [
+        "aktuality.sk",
+        "sky.it",
+        "azet.sk",
+        "bloomberg.com",
+        "formula1.com"
+      ],
       "id": "ae8f7761-35ff-45b2-92df-7868ca288ad2"
     },
     {

--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -6135,33 +6135,6 @@
       }
     },
     {
-      "id": "351f17c2-54b7-4a43-a425-b53bf5950b2e",
-      "domains": ["zyxel.com"],
-      "cookies": {
-        "optIn": [
-          {
-            "name": "cookie-agreed",
-            "value": "2"
-          },
-          {
-            "name": "cookie-agreed-version",
-            "value": "1.0.0"
-          }
-        ],
-        "optOut": [
-          {
-            "name": "cookie-agreed",
-            "value": "0"
-          }
-        ]
-      },
-      "click": {
-        "presence": ".eu-cookie-compliance-banner",
-        "optOut": ".decline-button",
-        "optIn": ".agree-button"
-      }
-    },
-    {
       "id": "ddff9528-161c-471e-bd2d-ba4d874a3931",
       "domains": ["nazwa.pl"],
       "cookies": {
@@ -6331,7 +6304,7 @@
     },
     {
       "id": "7AF1C34C-750E-44FC-A3C4-31FB61EBF71B",
-      "domains": ["deskmodder.de"],
+      "domains": ["deskmodder.de", "zyxel.com"],
       "click": {
         "optIn": "#cookiescript_accept",
         "optOut": "#cookiescript_reject",

--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -1265,13 +1265,13 @@
       "domains": ["idokep.hu"]
     },
     {
-      "click": {
-        "optIn": "button.js-accept",
-        "presence": "div.cookie-banner-buttons"
-      },
-      "cookies": {},
       "id": "dbbccc0a-13ba-4cd8-9cf0-32420401be55",
-      "domains": ["emag.ro"]
+      "domains": ["emag.bg", "emag.hu", "emag.ro"],
+      "click": {
+        "presence": ".cookie-banner-buttons",
+        "optOut": ".js-refuse",
+        "optIn": ".js-accept"
+      }
     },
     {
       "click": {
@@ -2446,15 +2446,6 @@
       "cookies": {},
       "id": "7e5d072f-ea5a-4a82-9ea4-3bbf06d5cc8d",
       "domains": ["nettiauto.com"]
-    },
-    {
-      "click": {
-        "optIn": "button.js-accept",
-        "presence": "div.cookie-banner-buttons"
-      },
-      "cookies": {},
-      "id": "e78a3fdb-bcba-402c-b2da-63994aba1b30",
-      "domains": ["emag.hu"]
     },
     {
       "click": {

--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -536,14 +536,18 @@
       "domains": ["youtube.com"]
     },
     {
-      "click": {
-        "optIn": "button[data-cookiebanner=\"accept_button\"]",
-        "optOut": "button[data-cookiebanner=\"accept_only_essential_button\"]",
-        "presence": "div[data-testid=\"cookie-policy-manage-dialog\"]"
-      },
-      "cookies": {},
       "id": "d1d8ba36-ced7-4453-8b17-2e051e0ab1eb",
-      "domains": ["facebook.com", "messenger.com", "oculus.com"]
+      "domains": [
+        "facebook.com",
+        "messenger.com",
+        "oculus.com",
+        "workplace.com"
+      ],
+      "click": {
+        "presence": "[data-testid=\"cookie-policy-manage-dialog\"]",
+        "optOut": "[data-cookiebanner=\"accept_only_essential_button\"]",
+        "optIn": "[data-cookiebanner=\"accept_button\"]"
+      }
     },
     {
       "cookies": {

--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -5860,7 +5860,7 @@
     },
     {
       "id": "04e919eb-13c2-4b37-bf7f-888767888640",
-      "domains": ["endorfy.com", "silentiumpc.com"],
+      "domains": ["endorfy.com", "krux.tech", "silentiumpc.com", "spcgear.com"],
       "cookies": {
         "optOut": [
           {

--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -2829,10 +2829,41 @@
         "radiofrance.fr",
         "rfi.fr",
         "rtl.fr",
-        "blablacar.fr",
         "6play.fr",
         "marianne.net"
       ]
+    },
+    {
+      "id": "3b20cf84-991e-4155-8620-4e897d703530",
+      "domains": [
+        "blablacar.be",
+        "blablacar.co.uk",
+        "blablacar.cz",
+        "blablacar.de",
+        "blablacar.es",
+        "blablacar.fr",
+        "blablacar.hr",
+        "blablacar.hu",
+        "blablacar.it",
+        "blablacar.nl",
+        "blablacar.pl",
+        "blablacar.pt",
+        "blablacar.ro",
+        "blablacar.sk"
+      ],
+      "cookies": {
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CXgyJwAXgyJwAAHABBENAtEgAAAAAAAAAAAAAAAAAAAA.YAAAAAAAAAAA"
+          }
+        ]
+      },
+      "click": {
+        "presence": "#didomi-popup",
+        "optOut": "#didomi-notice-disagree-button",
+        "optIn": "#didomi-notice-agree-button"
+      }
     },
     {
       "click": {
@@ -6612,6 +6643,26 @@
         "optIn": "#accept-btn",
         "optOut": "#decline-btn",
         "presence": "#privacy-manager-popin"
+      }
+    },
+    {
+      "id": "2f4e1235-a360-46ca-bf26-8b09645ee3d5",
+      "domains": [
+        "blablacar.com.br",
+        "blablacar.com.tr",
+        "blablacar.com.ua",
+        "blablacar.in",
+        "blablacar.mx",
+        "blablacar.rs",
+        "blablacar.ru"
+      ],
+      "cookies": {
+        "optIn": [
+          {
+            "name": "_cookies_v2",
+            "value": "1"
+          }
+        ]
       }
     }
   ]

--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -856,10 +856,38 @@
       "domains": ["bitly.com"]
     },
     {
-      "click": {},
-      "cookies": { "optOut": [{ "name": "gdpr", "value": "1" }] },
       "id": "37319f5d-9484-4da8-aee1-570a78688da3",
-      "domains": ["yandex.com", "yandex.ru", "ya.ru", "kinopoisk.ru"]
+      "domains": [
+        "kinopoisk.ru",
+        "ya.ru",
+        "yandex.az",
+        "yandex.by",
+        "yandex.co.il",
+        "yandex.com",
+        "yandex.com.am",
+        "yandex.com.ge",
+        "yandex.com.tr",
+        "yandex.ee",
+        "yandex.eu",
+        "yandex.kz",
+        "yandex.lt",
+        "yandex.lv",
+        "yandex.md",
+        "yandex.pt",
+        "yandex.ru",
+        "yandex.tj",
+        "yandex.tm",
+        "yandex.uz",
+        "yandex.vc"
+      ],
+      "cookies": {
+        "optOut": [
+          {
+            "name": "gdpr",
+            "value": "1"
+          }
+        ]
+      }
     },
     {
       "click": {},

--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -608,14 +608,33 @@
       "domains": ["linkedin.com"]
     },
     {
-      "click": {
-        "optIn": "button#gdpr-banner-accept",
-        "optOut": "button#gdpr-banner-decline",
-        "presence": "div#gdpr-banner"
-      },
-      "cookies": {},
       "id": "1e6d35e7-b907-4f5c-a09a-9f3336ef6e61",
-      "domains": ["ebay.com", "ebay.de", "ebay.co.uk"]
+      "domains": [
+        "ebay.at",
+        "ebay.be",
+        "ebay.ca",
+        "ebay.ch",
+        "ebay.co.uk",
+        "ebay.com",
+        "ebay.com.au",
+        "ebay.com.hk",
+        "ebay.com.my",
+        "ebay.com.sg",
+        "ebay.de",
+        "ebay.es",
+        "ebay.fr",
+        "ebay.ie",
+        "ebay.it",
+        "ebay.nl",
+        "ebay.ph",
+        "ebay.pl",
+        "ebay.vn"
+      ],
+      "click": {
+        "presence": "#gdpr-banner",
+        "optOut": "#gdpr-banner-decline",
+        "optIn": "#gdpr-banner-accept"
+      }
     },
     {
       "click": {
@@ -2334,16 +2353,6 @@
       "cookies": {},
       "id": "da1104e6-0ce0-4956-bd53-fd13c5c2c90b",
       "domains": ["nemzetisport.hu"]
-    },
-    {
-      "click": {
-        "optIn": "button#gdpr-banner-accept",
-        "optOut": "button#gdpr-banner-decline",
-        "presence": "div.gdpr-banner__wrapper"
-      },
-      "cookies": {},
-      "id": "0bee4c78-484e-4f21-8585-f089bc7618f5",
-      "domains": ["ebay.it"]
     },
     {
       "click": {

--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -1798,7 +1798,6 @@
         "zdnet.de",
         "zdnet.fr",
         "intersport.fr",
-        "decathlon.fr",
         "leboncoin.fr",
         "boursorama.com",
         "boursobank.com",
@@ -1815,14 +1814,49 @@
       ]
     },
     {
-      "click": {
-        "optIn": "#didomi-notice-agree-button",
-        "optOut": ".didomi-continue-without-agreeing",
-        "presence": "div#didomi-notice"
+      "id": "05b53737-a488-4312-b845-72d804872158",
+      "domains": [
+        "decathlon.ch",
+        "decathlon.co.uk",
+        "decathlon.es",
+        "decathlon.fr",
+        "decathlon.hu",
+        "decathlon.media",
+        "decathlon.mt",
+        "decathlon.nl",
+        "decathlon.yoga",
+        "quechua.fr"
+      ],
+      "cookies": {
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CXgyJwAXgyJwAAHABBENAtEgAAAAAAAAAAAAAAAAAAAA.YAAAAAAAAAAA"
+          }
+        ]
       },
-      "cookies": {},
-      "id": "688d29a8-e1c7-4d62-b3d4-53b451ff5a48",
-      "domains": ["orange.sk", "hnonline.sk"]
+      "click": {
+        "presence": "#didomi-popup",
+        "optOut": ".didomi-continue-without-agreeing",
+        "optIn": "#didomi-notice-agree-button"
+      }
+    },
+    {
+      "id": "5da98b86-9a16-47ec-8607-046744d93396",
+      "domains": ["decathlon.cz", "decathlon.it", "hnonline.sk", "orange.sk"],
+      "cookies": {
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CXgyJwAXgyJwAAHABBENAtEgAAAAAAAAAAAAAAAAAAAA.YAAAAAAAAAAA"
+          }
+        ]
+      },
+      "click": {
+        "presence": "#didomi-notice",
+        "optOut": ".didomi-continue-without-agreeing",
+        "optIn": "#didomi-notice-agree-button"
+      }
     },
     {
       "click": { "optIn": "a.cmptxt_btn_yes", "presence": "div.cmpboxinner" },
@@ -2856,7 +2890,16 @@
         "blablacar.pl",
         "blablacar.pt",
         "blablacar.ro",
-        "blablacar.sk"
+        "blablacar.sk",
+        "decathlon-united.media",
+        "decathlon.at",
+        "decathlon.be",
+        "decathlon.com.dz",
+        "decathlon.de",
+        "decathlon.pl",
+        "decathlon.pt",
+        "decathlon.ro",
+        "decathlon.sk"
       ],
       "cookies": {
         "optOut": [
@@ -2869,6 +2912,23 @@
       "click": {
         "presence": "#didomi-popup",
         "optOut": "#didomi-notice-disagree-button",
+        "optIn": "#didomi-notice-agree-button"
+      }
+    },
+    {
+      "id": "e4b0998b-a54c-458d-935b-6ec957175711",
+      "domains": ["decathlon.ee"],
+      "cookies": {
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CXgyJwAXgyJwAAHABBENAtEgAAAAAAAAAAAAAAAAAAAA.YAAAAAAAAAAA"
+          }
+        ]
+      },
+      "click": {
+        "presence": "#didomi-popup",
+        "optOut": "#didomi-notice-x-button",
         "optIn": "#didomi-notice-agree-button"
       }
     },
@@ -5208,6 +5268,8 @@
       },
       "id": "8f401b10-02b6-4e05-88fa-c37012d4c8c0",
       "domains": [
+        "decathlon.nc",
+        "decathlon.re",
         "magnite.com",
         "mecklenburg-vorpommern.de",
         "omv.com",
@@ -5374,17 +5436,42 @@
     },
     {
       "id": "05157ed1-12c2-4f84-9dff-718fae5bc096",
-      "domains": ["reverso.net"],
+      "domains": [
+        "decathlon.bg",
+        "decathlon.ca",
+        "decathlon.hr",
+        "decathlon.ie",
+        "decathlon.lt",
+        "decathlon.lv",
+        "decathlon.se",
+        "reverso.net"
+      ],
       "cookies": {
         "optOut": [
           {
             "name": "euconsent-v2",
-            "value": "CRolnUARolnUAAHABBENDHCgAAAAAAAAAAAAAAAAAAAA.YAAAAAAAAAAA"
+            "value": "CXgyJwAXgyJwAAHABBENAtEgAAAAAAAAAAAAAAAAAAAA.YAAAAAAAAAAA"
           }
         ]
       },
       "click": {
         "presence": "#didomi-popup",
+        "optIn": "#didomi-notice-agree-button"
+      }
+    },
+    {
+      "id": "83ad4c2f-e59a-4295-a342-5db40fb81763",
+      "domains": ["decathlon.si"],
+      "cookies": {
+        "optOut": [
+          {
+            "name": "euconsent-v2",
+            "value": "CXgyJwAXgyJwAAHABBENAtEgAAAAAAAAAAAAAAAAAAAA.YAAAAAAAAAAA"
+          }
+        ]
+      },
+      "click": {
+        "presence": "#didomi-notice",
         "optIn": "#didomi-notice-agree-button"
       }
     },
@@ -6762,6 +6849,15 @@
         "presence": "#ppms_cm_popup_overlay",
         "optOut": "#ppms_cm_reject-all",
         "optIn": "#ppms_cm_agree-to-all"
+      }
+    },
+    {
+      "id": "1da8a6ad-f894-400e-8b3d-2a281015b86d",
+      "domains": ["decathlon.com.sa", "decathlon.gp", "decathlon.mq"],
+      "click": {
+        "presence": "#shopify-pc__banner",
+        "optOut": "#shopify-pc__banner__btn-decline",
+        "optIn": "#shopify-pc__banner__btn-accept"
       }
     }
   ]

--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -6505,6 +6505,15 @@
         "optOut": "#c-bns button.grey",
         "presence": "#cm"
       }
+    },
+    {
+      "id": "7b2e3401-697f-440a-b418-8477fcf2cfeb",
+      "domains": ["canalplus.com"],
+      "click": {
+        "optIn": "#accept-btn",
+        "optOut": "#decline-btn",
+        "presence": "#privacy-manager-popin"
+      }
     }
   ]
 }

--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -2768,6 +2768,7 @@
         "opodo.pt",
         "radiofrance.fr",
         "rfi.fr",
+        "rtl.fr",
         "blablacar.fr",
         "6play.fr",
         "marianne.net"

--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -86,13 +86,16 @@
       "domains": [
         "tumblr.com",
         "paypal.com",
-        "amazon.se",
-        "amazon.fr",
-        "amazon.nl",
-        "amazon.es",
         "amazon.co.uk",
+        "amazon.com.be",
+        "amazon.com.tr",
         "amazon.de",
-        "amazon.it"
+        "amazon.es",
+        "amazon.fr",
+        "amazon.it",
+        "amazon.nl",
+        "amazon.pl",
+        "amazon.se"
       ]
     },
     {


### PR DESCRIPTION
Companies usually have different variations of their websites adapted to the characteristics of different markets. Some of them also use different addresses for each one, as Zalando does, for example (which, among others, is part of this PR).

In this pull request, I propose adding support for such localized websites. The full list looks as follows:
- Amazon websites
- BlaBlaCar websites
- CHIP-branded websites
- Crédit Agricole websites
- Decathlon websites
- Ebay websites
- eMAG websites
- Intermarché-branded websites
- INTERSPORT websites
- MediaMarktSaturn websites
- Orange-branded websites
- Pepper platform websites
- Telekom/T-mobile/Magenta-branded websites
- Vodafone websites
- Yandex websites
- Zalando websites
- ZDNET-branded websites

To make the review process easier, I have provided a separate commit for each entry on the list. However, if the review process is successful and you proceed to merge, please squash all of these commits into one, as there is really no reason to keep them separate outside of this pull request.

I would also like to thank @MikeFH for encouraging me in #480 to finally get down to it :)

Resolves #450
Closes #40