### PR TITLE
Added support for the new cookie banner on asus.com

### DIFF
--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -4085,6 +4085,18 @@
     {
       "id": "8c949b75-4c7b-4559-8ade-780064af370a",
       "domains": ["asus.com"],
+      "cookies": {
+        "optOut": [
+          {
+            "name": "isReadCookiePolicyDNT",
+            "value": "No"
+          },
+          {
+            "name": "isReadCookiePolicyDNTAa",
+            "value": "false"
+          }
+        ]
+      },
       "click": {
         "presence": "#cookie-policy-info",
         "optOut": ".btn-reject",


### PR DESCRIPTION
In this pull request, I propose to add support for the new cookie banner on asus.com (see the linked issue below for a screenshot and more details) by adding a rule for injecting cookies, as the new banner no longer has any cookie reject button to click.

As I said in the linked issue below, I don't know what Asus plans to do next with these banners. Will the new one replace the old one at some point, or maybe Asus will return to the old banner, or maybe everything will remain as it is (because different countries have different rules regarding the protection of personal data).

So for now, while the old banner is still in use, the newly added cookie injection support should handle both the new and old one. The mechanism for clicking the cookie reject button would remain as a fallback for the old banner until it is completely replaced by the new one (if that happens at all). Then, sometime in the future, this rule for asus.com will probably need to be revisited to clean it up and remove the opt-out click rule altogether.

Fixes #492