### PR TITLE
Add optOut in rule for fandom.com

### DIFF
--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -5380,7 +5380,8 @@
     {
       "click": {
         "presence": "div[data-tracking-opt-in-overlay=\"true\"]",
-        "optIn": "div[data-tracking-opt-in-accept=\"true\"]"
+        "optIn": "div[data-tracking-opt-in-accept=\"true\"]",
+        "optOut": "div[data-tracking-opt-in-reject=\"true\"]"
       },
       "id": "D168AF87-F481-4AD7-BE78-28A59F798406",
       "domains": ["fandom.com"]


### PR DESCRIPTION
https://www.fandom.com/

This site has a lot of subdomains. A few random examples : 
* https://godzilla.fandom.com
* https://dcextendeduniverse.fandom.com
* https://matrix.fandom.com