### PR TITLE
Fix rule for gdpr.twitter.com

### DIFF
--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -584,6 +584,10 @@
           {
             "name": "d_prefs",
             "value": "MjoxLGNvbnNlbnRfdmVyc2lvbjoyLHRleHRfdmVyc2lvbjoxMDAw"
+          },
+          {
+            "name": "twtr_pixel_opt_in",
+            "value": "N"
           }
         ],
         "optIn": [


### PR DESCRIPTION
## Example URL

`https://gdpr.twitter.com`

## Screenshot

<img width="1028" alt="Screenshot 2024-04-14 at 15 20 58" src="https://github.com/mozilla/cookie-banner-rules-list/assets/80652640/eae1eefe-efcf-4629-b3f0-95de8b0ba05c">

Tested on Firefox 125.0b9

Tried to add a rule specific to the subdomain (not sure if it applies to others), but it wouldn't apply due to existing `twitter.com` rule.