### PR TITLE
Added partial support for meta.com and instagram.com

### DIFF
--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -550,7 +550,9 @@
       "id": "d1d8ba36-ced7-4453-8b17-2e051e0ab1eb",
       "domains": [
         "facebook.com",
+        "instagram.com",
         "messenger.com",
+        "meta.com",
         "oculus.com",
         "workplace.com"
       ],


### PR DESCRIPTION
In this pull request, I modified the existing rule for the standard cookie banner used by Meta on a large part of their websites to enable automatic handling of this banner by the Firefox cookie banner blocker on some of the meta.com and instagram.com subdomains that use it.

Also, just to make this extra clear and for future reference, I'm adding meta.com and instagram.com to the rule list _not_ to add support for the main banners on both of these websites but to make about.meta.com and about.instagram.com supported respectively (and probably other subdomains I missed).

Resolves #476
Resolves #499