### PR TITLE
Add rule for x.com

### DIFF
--- a/cookie-banner-rules-list.json
+++ b/cookie-banner-rules-list.json
@@ -637,7 +637,7 @@
         ]
       },
       "id": "05b3b417-c4c7-4ed0-a3cf-43053e8b33ab",
-      "domains": ["twitter.com"]
+      "domains": ["twitter.com", "x.com"]
     },
     {
       "click": {


### PR DESCRIPTION
## Example URL

* `https://x.com`
* `https://gdpr.x.com`

## Screenshot

<img width="955" alt="Screenshot 2024-05-19 at 23 28 04" src="https://github.com/mozilla/cookie-banner-rules-list/assets/80652640/6feff35c-83ad-4f26-9b32-96c34dacb05f">

Tested on 127.0b4